### PR TITLE
Harden database SSL verification defaults

### DIFF
--- a/src/helpers/database.js
+++ b/src/helpers/database.js
@@ -3,12 +3,13 @@ const { Pool } = require('pg');
 const { detectCountryCode } = require('./localization');
 const { logDetails } = require('../utils/logging-utils');
 
+const sslEnabled = process.env.DATABASE_SSL !== 'false';
+const rejectUnauthorized = process.env.DATABASE_SSL_REJECT_UNAUTHORIZED !== 'false';
+
 // Create a connection pool
 const pool = new Pool({
   connectionString: process.env.DATABASE_URL,
-  ssl: { 
-    rejectUnauthorized: false 
-  }
+  ssl: sslEnabled ? { rejectUnauthorized } : false
 });
 
 // Check if a user exists by phone number, create if not


### PR DESCRIPTION
### Motivation
- Close a security gap where database SSL connections did not verify server certificates by default.
- Prevent potential MITM or unauthorized DB connections by enabling certificate verification.
- Allow deployments to explicitly opt out when necessary via environment flags.

### Description
- Updated `src/helpers/database.js` to compute `sslEnabled` and `rejectUnauthorized` from `process.env.DATABASE_SSL` and `process.env.DATABASE_SSL_REJECT_UNAUTHORIZED`.
- Set the `pg` `Pool` `ssl` option to `sslEnabled ? { rejectUnauthorized } : false` so certificate verification is on by default.
- Documented opt-out behavior via the two environment variables and made no other behavioral changes to DB helper functions.

### Testing
- No automated tests were run (CI not executed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6957abced488833282f377c9edcdd1a6)