### PR TITLE
Switch to gpt-4o-mini models for transcription and summaries

### DIFF
--- a/src/helpers/transcription.js
+++ b/src/helpers/transcription.js
@@ -6,7 +6,7 @@ async function generateSummary(text, language, context) {
     const response = await axios.post(
       'https://api.openai.com/v1/chat/completions',
       {
-        model: "gpt-3.5-turbo",
+        model: "gpt-4o-mini",
         messages: [
           {
             role: "system",

--- a/src/services/audio-service.js
+++ b/src/services/audio-service.js
@@ -46,7 +46,7 @@ async function downloadAudio(mediaUrl, headers = {}, req = null) {
   }
 }
 
-function prepareFormData(audioData, contentType, model = 'whisper-1') {
+function prepareFormData(audioData, contentType, model = 'gpt-4o-mini-transcribe') {
   const formData = new FormData();
   
   formData.append('file', Buffer.from(audioData), {


### PR DESCRIPTION
### Motivation
- Replace the legacy `whisper-1` speech-to-text default with the recommended `gpt-4o-mini-transcribe` for faster, newer STT performance.
- Replace `gpt-3.5-turbo` with `gpt-4o-mini` for summarization as the recommended, more capable chat model.
- Keep existing request flows and endpoints while updating only the model identifiers to follow OpenAI recommendations.

### Description
- Change default model parameter in `prepareFormData` in `src/services/audio-service.js` from `whisper-1` to `gpt-4o-mini-transcribe`.
- Update the `model` field in the chat completion request in `src/helpers/transcription.js` from `gpt-3.5-turbo` to `gpt-4o-mini`.
- No other payload or header changes were made to the transcription/summarization requests.

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6957bff3621c8332b5f6794c28866e3f)