### PR TITLE
Add Netlify Functions deployment alongside the Express server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ logs/
 Thumbs.db
 .idea/
 .vscode/
+
+# Netlify CLI local cache
+.netlify/

--- a/README.md
+++ b/README.md
@@ -14,16 +14,41 @@ A Node.js/Express backend that powers a WhatsApp-based voice note transcription 
 ```
 .
 ├── src/
+│   ├── app.js          # Express app definition (shared by server + serverless)
+│   ├── index.js        # Server entry point (Heroku / local dev)
 │   ├── controllers/    # Request handlers and business logic
+│   ├── core/           # Voice-note pipeline (Express-free, shared)
 │   ├── helpers/        # Localization and transcription helpers
 │   ├── middleware/     # Request processing utilities
 │   ├── routes/         # Express route definitions
 │   ├── services/       # External service integrations (e.g., Twilio)
 │   └── utils/          # Shared utilities and logging
-├── test/               # Test helpers and mocks
+├── netlify/functions/  # Netlify deployment (sync webhook + background worker)
+├── public/             # Static landing page (Netlify publish dir)
+├── netlify.toml        # Netlify build config + /transcribe rewrite
 ├── index.js            # Entry point (loads src/index.js)
 └── package.json
 ```
+
+## Deployment
+
+The app runs in two modes from the same codebase:
+
+- **Server mode** (Heroku / any Node host): `npm start` runs the Express
+  server; the whole pipeline executes inside the webhook request.
+- **Netlify mode**: `netlify/functions/transcribe.js` acks the Twilio
+  webhook instantly (signature-validated), dedupes on `MessageSid` via
+  Netlify Blobs, and hands the pipeline to
+  `transcribe-background.js` (15-minute budget). Fast flows (welcome,
+  non-audio, test mode) are served by the same Express app via
+  `serverless-http`. Point the Twilio webhook at
+  `https://<site>/transcribe`.
+
+Netlify-only environment variables (set in the Netlify UI, in addition
+to the ones below): `INTERNAL_API_SECRET` (random 32+ chars; auth
+between the two functions) and `TWILIO_WEBHOOK_URL` (the exact URL
+configured in Twilio, used for signature validation). Set
+`TWILIO_SIGNATURE_VALIDATION=off` only for local development.
 
 ## Requirements
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,20 @@
+# Netlify configuration for the Josephine transcription service.
+# The site is functions-only; `public/` holds a minimal landing page.
+[build]
+  publish = "public"
+  functions = "netlify/functions"
+
+[functions]
+  node_bundler = "esbuild"
+
+# Keep the public webhook URL clean and stable: Twilio posts to
+# https://<site>/transcribe and this rewrite (status 200 = proxy, not a
+# redirect — Twilio never sees a 3xx) forwards it to the sync function.
+# The Twilio signature is computed over the public URL, so the function
+# validates against TWILIO_WEBHOOK_URL (or event.rawUrl), never the
+# internal /.netlify/functions/* path.
+[[redirects]]
+  from = "/transcribe"
+  to = "/.netlify/functions/transcribe"
+  status = 200
+  force = true

--- a/netlify/functions/lib/shared.js
+++ b/netlify/functions/lib/shared.js
@@ -1,0 +1,18 @@
+// netlify/functions/lib/shared.js
+// Small helpers shared by the sync webhook and the background worker.
+const { getStore } = require('@netlify/blobs');
+
+// The empty TwiML ack Twilio expects (matches the Express app's response).
+const EMPTY_TWIML = '<Response></Response>';
+
+// Blobs store used for MessageSid idempotency. Strong consistency so a
+// Twilio webhook retry (seconds later) sees the marker immediately.
+// Marker lifecycle: dispatched -> processing -> done | failed | retrying
+function getProcessedStore() {
+  return getStore({ name: 'processed-messages', consistency: 'strong' });
+}
+
+module.exports = {
+  EMPTY_TWIML,
+  getProcessedStore
+};

--- a/netlify/functions/transcribe-background.js
+++ b/netlify/functions/transcribe-background.js
@@ -1,0 +1,82 @@
+// netlify/functions/transcribe-background.js
+// Background worker (the "-background" suffix gives it a 15-minute budget;
+// Netlify acks invocations with 202 immediately and auto-retries failed
+// runs after 1 min, then 2 min).
+//
+// Runs the full voice-note pipeline via src/core/voice-note-pipeline.js —
+// download, Whisper, moderation, optional summary, Twilio sends. On any
+// handled failure the pipeline itself messages the user with the existing
+// localized error text, so nothing fails silently.
+//
+// Idempotency marker (Netlify Blobs, key = MessageSid):
+//   done / failed  -> terminal, exit without reprocessing
+//   anything else  -> process (covers first delivery, crash retries, and
+//                     'retrying' set after a failed Twilio send)
+const { TwilioClientWrapper } = require('../../src/services/twilio-service');
+const { processVoiceNote } = require('../../src/core/voice-note-pipeline');
+const { logDetails } = require('../../src/utils/logging-utils');
+const { getProcessedStore } = require('./lib/shared');
+
+exports.handler = async (event) => {
+  // Only our own sync function may invoke this endpoint.
+  const token = (event.headers && (event.headers['x-internal-token'] || event.headers['X-Internal-Token'])) || '';
+  if (!process.env.INTERNAL_API_SECRET || token !== process.env.INTERNAL_API_SECRET) {
+    logDetails('Rejected background invocation with missing/invalid internal token');
+    return { statusCode: 401, body: 'Unauthorized' };
+  }
+
+  let params;
+  try {
+    params = JSON.parse(event.body || '{}');
+  } catch (e) {
+    return { statusCode: 400, body: 'Invalid JSON payload' };
+  }
+
+  const sid = params.MessageSid;
+  if (!sid || !params.MediaUrl0) {
+    return { statusCode: 400, body: 'Missing MessageSid or MediaUrl0' };
+  }
+
+  // Idempotency check — fail-open (a Blobs hiccup must not drop the job).
+  let store = null;
+  try {
+    store = getProcessedStore();
+    const marker = await store.get(sid, { type: 'json' });
+    if (marker && (marker.status === 'done' || marker.status === 'failed')) {
+      logDetails(`Skipping ${sid}: already ${marker.status}`);
+      return { statusCode: 200, body: 'Already processed' };
+    }
+    await store.setJSON(sid, { status: 'processing', at: new Date().toISOString() });
+  } catch (blobError) {
+    logDetails('Blobs unavailable in background, proceeding without markers:', blobError.message);
+    store = null;
+  }
+
+  // Build a req-like context for the shared pipeline and services.
+  const context = { body: params, isTestMode: false, testResults: null };
+  context.twilioClient = new TwilioClientWrapper(context);
+
+  const result = await processVoiceNote(context);
+
+  // Terminal states: 'done' (user got transcription or violation notice),
+  // 'failed' (user got the localized error message — do not re-spend).
+  // 'retrying': the pipeline succeeded but the Twilio send failed, so the
+  // user got NOTHING — throw to trigger Netlify's automatic retry.
+  const status = result.flow === 'twilio_error'
+    ? 'retrying'
+    : (result.flow === 'processing_error' ? 'failed' : 'done');
+
+  if (store) {
+    try {
+      await store.setJSON(sid, { status, flow: result.flow, at: new Date().toISOString() });
+    } catch (e) { /* best effort */ }
+  }
+
+  if (result.flow === 'twilio_error') {
+    logDetails(`Twilio send failed for ${sid}, throwing to trigger platform retry`, { error: result.error });
+    throw new Error(`Twilio send failed for ${sid}: ${result.error}`);
+  }
+
+  logDetails(`Background processing finished for ${sid}: ${result.flow}`);
+  return { statusCode: 200, body: result.flow };
+};

--- a/netlify/functions/transcribe.js
+++ b/netlify/functions/transcribe.js
@@ -1,0 +1,124 @@
+// netlify/functions/transcribe.js
+// Synchronous webhook endpoint (Twilio posts here via the /transcribe rewrite).
+//
+// Responsibilities (must finish well under the 10s sync limit):
+//   1. Validate the X-Twilio-Signature on production requests.
+//   2. Production voice notes: dedup on MessageSid (Netlify Blobs), then
+//      dispatch to the background function and ack Twilio with empty TwiML.
+//   3. Everything else (welcome, non-audio, API info, language test, and
+//      ALL test-mode flows) is delegated to the unchanged Express app —
+//      those paths are fast (fully mocked, or at most one Twilio REST call).
+const querystring = require('querystring');
+const serverless = require('serverless-http');
+const twilio = require('twilio');
+const app = require('../../src/app');
+const { logDetails } = require('../../src/utils/logging-utils');
+const { getProcessedStore, EMPTY_TWIML } = require('./lib/shared');
+
+const expressHandler = serverless(app);
+
+function getHeader(event, name) {
+  const headers = event.headers || {};
+  return headers[name] || headers[name.toLowerCase()] || headers[name.toUpperCase()] || '';
+}
+
+function parseParams(event) {
+  const raw = event.isBase64Encoded
+    ? Buffer.from(event.body || '', 'base64').toString('utf8')
+    : (event.body || '');
+  const contentType = getHeader(event, 'content-type');
+  if (contentType.includes('application/json')) {
+    try { return JSON.parse(raw); } catch (e) { return {}; }
+  }
+  return { ...querystring.parse(raw) };
+}
+
+function isTestMode(event, params) {
+  return (
+    getHeader(event, 'x-test-mode') === 'true' ||
+    (event.queryStringParameters && event.queryStringParameters.testMode === 'true') ||
+    params.testMode === 'true'
+  );
+}
+
+function twimlResponse() {
+  return {
+    statusCode: 200,
+    headers: { 'Content-Type': 'text/xml' },
+    body: EMPTY_TWIML
+  };
+}
+
+exports.handler = async (event, context) => {
+  const params = parseParams(event);
+  const testMode = isTestMode(event, params);
+
+  // 1. Twilio signature validation — required for any production request
+  //    carrying a MessageSid (those trigger real sends / real spend).
+  //    Test mode is exempt: it is mocked end to end and spends nothing.
+  if (!testMode && params.MessageSid && process.env.TWILIO_SIGNATURE_VALIDATION !== 'off') {
+    const signature = getHeader(event, 'x-twilio-signature');
+    const url = process.env.TWILIO_WEBHOOK_URL || event.rawUrl;
+    const valid = twilio.validateRequest(process.env.AUTH_TOKEN || '', signature, url, params);
+    if (!valid) {
+      logDetails('Rejected request with invalid Twilio signature', { url });
+      return { statusCode: 403, body: 'Invalid Twilio signature' };
+    }
+  }
+
+  // 2. Production voice note → dedup + background dispatch + instant ack
+  const isProdVoiceNote =
+    !testMode &&
+    params.MessageSid &&
+    parseInt(params.NumMedia || 0) > 0 &&
+    params.MediaContentType0 &&
+    params.MediaContentType0.startsWith('audio/') &&
+    params.MediaUrl0;
+
+  if (isProdVoiceNote) {
+    // Dedup is fail-open: a Blobs hiccup must never block a transcription.
+    let store = null;
+    try {
+      store = getProcessedStore();
+      const existing = await store.get(params.MessageSid, { type: 'json' });
+      if (existing) {
+        logDetails(`Duplicate webhook for ${params.MessageSid} (status=${existing.status}) — acking without re-dispatch`);
+        return twimlResponse();
+      }
+      await store.setJSON(params.MessageSid, { status: 'dispatched', at: new Date().toISOString() });
+    } catch (blobError) {
+      logDetails('Blobs unavailable, proceeding without dedup:', blobError.message);
+      store = null;
+    }
+
+    // Dispatch to the background function (acks 202 as soon as queued).
+    try {
+      const response = await fetch(`${process.env.URL}/.netlify/functions/transcribe-background`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'x-internal-token': process.env.INTERNAL_API_SECRET || ''
+        },
+        body: JSON.stringify(params)
+      });
+      if (response.status < 200 || response.status >= 300) {
+        throw new Error(`Background dispatch returned ${response.status}`);
+      }
+    } catch (dispatchError) {
+      // Roll back the dedup marker so Twilio's retry can re-dispatch.
+      logDetails('Background dispatch failed:', dispatchError.message);
+      if (store) {
+        try { await store.delete(params.MessageSid); } catch (e) { /* best effort */ }
+      }
+      return { statusCode: 500, body: 'Failed to queue transcription' };
+    }
+
+    logDetails(`Dispatched ${params.MessageSid} to background processing`);
+    return twimlResponse();
+  }
+
+  // 3. Everything else → the unchanged Express app.
+  //    Normalize the path so both /transcribe (rewrite) and the direct
+  //    function URL reach the Express /transcribe route.
+  return expressHandler({ ...event, path: '/transcribe' }, context);
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,10 +8,12 @@
       "name": "josephine-backend",
       "version": "1.0.0",
       "dependencies": {
+        "@netlify/blobs": "^10.7.9",
         "axios": "^1.4.0",
         "dotenv": "^16.0.3",
         "express": "^4.18.2",
         "form-data": "^4.0.0",
+        "serverless-http": "^4.0.0",
         "twilio": "^3.83.0"
       },
       "devDependencies": {
@@ -19,6 +21,322 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@envelop/instrumentation": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@envelop/instrumentation/-/instrumentation-1.0.0.tgz",
+      "integrity": "sha512-cxgkB66RQB95H3X27jlnxCRNTmPuSTgmBAq6/4n2Dtv4hsk4yz8FadA1ggmd0uZzvKqWD6CR+WFgTjhDqg7eyw==",
+      "license": "MIT",
+      "dependencies": {
+        "@whatwg-node/promise-helpers": "^1.2.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@fastify/busboy": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-3.2.0.tgz",
+      "integrity": "sha512-m9FVDXU3GT2ITSe0UaMA5rU3QkfC/UXtCU8y0gSN/GugTqtVldOBWIB5V6V3sbmenVZUIpU6f+mPEO2+m5iTaA==",
+      "license": "MIT"
+    },
+    "node_modules/@netlify/blobs": {
+      "version": "10.7.9",
+      "resolved": "https://registry.npmjs.org/@netlify/blobs/-/blobs-10.7.9.tgz",
+      "integrity": "sha512-NEM8aNAMZCCWBWymomMM/fn5wmPGyGE8pendgsSu5mL7UNz+aXqGcHS0MiHWU/osyg+geiZuS+Rx956SVrMM/w==",
+      "license": "MIT",
+      "dependencies": {
+        "@netlify/dev-utils": "4.4.6",
+        "@netlify/otel": "^6.0.3",
+        "@netlify/runtime-utils": "2.3.0"
+      },
+      "engines": {
+        "node": "^14.16.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@netlify/dev-utils": {
+      "version": "4.4.6",
+      "resolved": "https://registry.npmjs.org/@netlify/dev-utils/-/dev-utils-4.4.6.tgz",
+      "integrity": "sha512-P6X+xS3glvhiTX6AAocYvnZtqXtWhvxMX4AdPgv2iw6cXjGL2criUveX7bSjp6DiyHfvQpNdG0ZRpeBEVAFf1g==",
+      "license": "MIT",
+      "dependencies": {
+        "@whatwg-node/server": "^0.10.0",
+        "ansis": "^4.1.0",
+        "atomically": "^2.0.3",
+        "chokidar": "^4.0.1",
+        "decache": "^4.6.2",
+        "dettle": "^1.0.5",
+        "dot-prop": "9.0.0",
+        "empathic": "^2.0.0",
+        "env-paths": "^3.0.0",
+        "image-size": "^2.0.2",
+        "js-image-generator": "^1.0.4",
+        "parse-gitignore": "^2.0.0",
+        "semver": "^7.7.2",
+        "tmp-promise": "^3.0.3"
+      },
+      "engines": {
+        "node": "^18.14.0 || >=20"
+      }
+    },
+    "node_modules/@netlify/dev-utils/node_modules/chokidar": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@netlify/dev-utils/node_modules/readdirp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.18.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@netlify/dev-utils/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@netlify/otel": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@netlify/otel/-/otel-6.0.3.tgz",
+      "integrity": "sha512-NIjIjB/aItiXKB6+wzSwfSyYqbNsVSzzlEPryxxTC5ZJiYSYSm82wAOcQ+9VdiufQyZO5t8jzHVPULo7a9L9sQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@opentelemetry/api": "1.9.0",
+        "@opentelemetry/core": "2.7.1",
+        "@opentelemetry/instrumentation": "^0.217.0",
+        "@opentelemetry/resources": "2.7.1",
+        "@opentelemetry/sdk-trace-node": "2.7.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || >=20.6.1"
+      }
+    },
+    "node_modules/@netlify/runtime-utils": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@netlify/runtime-utils/-/runtime-utils-2.3.0.tgz",
+      "integrity": "sha512-cW8weDvsKV7zfia2m5EcBy6KILGoPD+eYZ3qWNGnIo05DGF28goPES0xKSDkNYgAF/2rRSIhie2qcBhbGVgSRg==",
+      "license": "MIT",
+      "engines": {
+        "node": "^18.14.0 || >=20"
+      }
+    },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
+      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/api-logs": {
+      "version": "0.217.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.217.0.tgz",
+      "integrity": "sha512-Cdq0jW2lknrNfrAm92MyEAvpe2cRsKjdnQLHUL6xRA4IVUnsWx6P65E7NcUO0Y+L4w1Aee5iV8FvjSwd+lrs9A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/context-async-hooks": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-2.7.1.tgz",
+      "integrity": "sha512-OPFBYuXEn1E4ja3Y6eeA7O+ZnLBNcXTV5Cgsn1VaqBZ6hC5FnpZPLBNme1LJY8ZtF4aOujPKFoeWN4ik487KuQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/core": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.7.1.tgz",
+      "integrity": "sha512-QAqIj32AtK6+pEVNG7EOVxHdE06RP+FM5qpiEJ4RtDcFIqKUZHYhl7/7UY5efhwmwNAg7j8QbJVBLxMerc0+gw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation": {
+      "version": "0.217.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.217.0.tgz",
+      "integrity": "sha512-24ucQMjz7Y34Kw3trbxL2ZrssbtgWnR+Clpaa+YdeWuuyH3Cvk23Q03PcQvqiZrDvt8AmQmjgg9v6Y9PHoxG7w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.217.0",
+        "import-in-the-middle": "^3.0.0",
+        "require-in-the-middle": "^8.0.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/resources": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.7.1.tgz",
+      "integrity": "sha512-DeT6KKolmC4e/dRQvMQ/RwlnzhaqeiFOXY5ngoOPJ07GgVVKxZOg9EcrNZb5aTzUn+iCrJldAgOfQm1O/QfPAQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.7.1",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.7.1.tgz",
+      "integrity": "sha512-NAYIlsF8MPUsKqJMiDQJTMPOmlbawC1Iz/omMLygZ1C9am8fTKYjTaI+OZM+WTY3t3Glo0wnOg/6/pac6RGPPw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.7.1",
+        "@opentelemetry/resources": "2.7.1",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-node": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-2.7.1.tgz",
+      "integrity": "sha512-pCpQxU68lV+I9s9svqMyVu5iHdDDUnqUpSxqwyCU8A9ejEsSnMPCbearwsUO4yk08ZJzAIUCFuReMdVQvHrdvg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/context-async-hooks": "2.7.1",
+        "@opentelemetry/core": "2.7.1",
+        "@opentelemetry/sdk-trace-base": "2.7.1"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.43.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.43.0.tgz",
+      "integrity": "sha512-eSYWTm620tTk45EKSedaUL8MFYI8hW164hIXsgIHyxu3VobUB3fFCu5t0hQby6OoWRPsG1KkKUG2M5UadiLiVg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@whatwg-node/disposablestack": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@whatwg-node/disposablestack/-/disposablestack-0.0.6.tgz",
+      "integrity": "sha512-LOtTn+JgJvX8WfBVJtF08TGrdjuFzGJc4mkP8EdDI8ADbvO7kiexYep1o8dwnt0okb0jYclCDXF13xU7Ge4zSw==",
+      "license": "MIT",
+      "dependencies": {
+        "@whatwg-node/promise-helpers": "^1.0.0",
+        "tslib": "^2.6.3"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@whatwg-node/fetch": {
+      "version": "0.10.13",
+      "resolved": "https://registry.npmjs.org/@whatwg-node/fetch/-/fetch-0.10.13.tgz",
+      "integrity": "sha512-b4PhJ+zYj4357zwk4TTuF2nEe0vVtOrwdsrNo5hL+u1ojXNhh1FgJ6pg1jzDlwlT4oBdzfSwaBwMCtFCsIWg8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@whatwg-node/node-fetch": "^0.8.3",
+        "urlpattern-polyfill": "^10.0.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@whatwg-node/node-fetch": {
+      "version": "0.8.6",
+      "resolved": "https://registry.npmjs.org/@whatwg-node/node-fetch/-/node-fetch-0.8.6.tgz",
+      "integrity": "sha512-BDMdYFcerLQkwA2RTldxOqRCs6ZQD1S7UgP3pUdGUkcbgTrP/V5ko77ZkCww9DHmC4lpoYuwigGfQYj285gMvA==",
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/busboy": "^3.1.1",
+        "@whatwg-node/disposablestack": "^0.0.6",
+        "@whatwg-node/promise-helpers": "^1.3.2",
+        "tslib": "^2.6.3"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@whatwg-node/promise-helpers": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@whatwg-node/promise-helpers/-/promise-helpers-1.3.2.tgz",
+      "integrity": "sha512-Nst5JdK47VIl9UcGwtv2Rcgyn5lWtZ0/mhRQ4G8NN2isxpq2TO30iqHzmwoJycjWuyUfg3GFXqP/gFHXeV57IA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.6.3"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@whatwg-node/server": {
+      "version": "0.10.18",
+      "resolved": "https://registry.npmjs.org/@whatwg-node/server/-/server-0.10.18.tgz",
+      "integrity": "sha512-kMwLlxUbduttIgaPdSkmEarFpP+mSY8FEm+QWMBRJwxOHWkri+cxd8KZHO9EMrB9vgUuz+5WEaCawaL5wGVoXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@envelop/instrumentation": "^1.0.0",
+        "@whatwg-node/disposablestack": "^0.0.6",
+        "@whatwg-node/fetch": "^0.10.13",
+        "@whatwg-node/promise-helpers": "^1.3.2",
+        "tslib": "^2.6.3"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/accepts": {
@@ -69,6 +387,15 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
+    "node_modules/ansis": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/ansis/-/ansis-4.3.1.tgz",
+      "integrity": "sha512-BJ8/l4R5LRE7hW9WdSuGYrLSHi2ynxeFpDFbH0K/CgNeY/tyhk+vO6TYxXC5r5CpUhNVX310xzPsN/H9lCdfOA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/anymatch": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
@@ -100,6 +427,16 @@
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
       "license": "MIT"
+    },
+    "node_modules/atomically": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/atomically/-/atomically-2.1.1.tgz",
+      "integrity": "sha512-P4w9o2dqARji6P7MHprklbfiArZAWvo07yW7qs3pdljb3BWr12FIB7W+p0zJiuiVsUpRO0iZn1kFFcpPegg0tQ==",
+      "license": "MIT",
+      "dependencies": {
+        "stubborn-fs": "^2.0.0",
+        "when-exit": "^2.1.4"
+      }
     },
     "node_modules/axios": {
       "version": "1.18.1",
@@ -225,6 +562,14 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/callsite": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz",
+      "integrity": "sha512-0vdNRFXn5q+dtOqjfFtmtlI9N2eVZ7LMyEV2iKC5mEEFvSg/69Ml6b/WU2qF8W1nLRa0wiSrDT3Y5jOHZCwKPQ==",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/chokidar": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
@@ -249,6 +594,12 @@
       "optionalDependencies": {
         "fsevents": "~2.3.2"
       }
+    },
+    "node_modules/cjs-module-lexer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-2.2.0.tgz",
+      "integrity": "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==",
+      "license": "MIT"
     },
     "node_modules/combined-stream": {
       "version": "1.0.8",
@@ -320,6 +671,15 @@
         "ms": "2.0.0"
       }
     },
+    "node_modules/decache": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/decache/-/decache-4.6.2.tgz",
+      "integrity": "sha512-2LPqkLeu8XWHU8qNCS3kcF6sCcb5zIzvWaAHYSvPfwhdd7mHuah29NssMzrTYyHN4F5oFy2ko9OBYxegtU0FEw==",
+      "license": "MIT",
+      "dependencies": {
+        "callsite": "^1.0.0"
+      }
+    },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -346,6 +706,27 @@
       "engines": {
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/dettle": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/dettle/-/dettle-1.0.5.tgz",
+      "integrity": "sha512-ZVyjhAJ7sCe1PNXEGveObOH9AC8QvMga3HJIghHawtG7mE4K5pW9nz/vDGAr/U7a3LWgdOzEE7ac9MURnyfaTA==",
+      "license": "MIT"
+    },
+    "node_modules/dot-prop": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-9.0.0.tgz",
+      "integrity": "sha512-1gxPBJpI/pcjQhKgIU91II6Wkay+dLcN3M6rf2uwP8hRur3HtQXjVrdAK3sjC0piaEuxzMwjXChcETiJl47lAQ==",
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^4.18.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/dotenv": {
@@ -389,6 +770,15 @@
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
       "license": "MIT"
     },
+    "node_modules/empathic": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/empathic/-/empathic-2.0.1.tgz",
+      "integrity": "sha512-YGRs8knHhKHVShLkFET/rWAU8kmHbOV5LwN938RHI0pljAJ1Gf6SzXsSmRaEzcXTtOOmVqJ5+WtQPL5uigY50Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/encodeurl": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
@@ -396,6 +786,18 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/env-paths": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-3.0.0.tgz",
+      "integrity": "sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/es-define-property": {
@@ -415,6 +817,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.0.tgz",
+      "integrity": "sha512-KLdwQm2NvGLDkQDCGvmiQrhkd0JbMzXthwQAUgWjQuQdBLFa3eiBP5arXZyA+f8x+x7OXgud6bq2rxjGtHV2tw==",
+      "license": "MIT"
     },
     "node_modules/es-object-atoms": {
       "version": "1.1.2",
@@ -799,6 +1207,32 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/image-size": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/image-size/-/image-size-2.0.2.tgz",
+      "integrity": "sha512-IRqXKlaXwgSMAMtpNzZa1ZAe8m+Sa1770Dhk8VkSsP9LS+iHD62Zd8FQKs8fbPiagBE7BzoFX23cxFnwshpV6w==",
+      "license": "MIT",
+      "bin": {
+        "image-size": "bin/image-size.js"
+      },
+      "engines": {
+        "node": ">=16.x"
+      }
+    },
+    "node_modules/import-in-the-middle": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-3.3.1.tgz",
+      "integrity": "sha512-0rymlHSFLwZ0ixx8DaQkoIyZojJPY2a0K2nEYslhKJ6jIYO/m0IcCb7iQsFPmS7WmKwISZiIrv5Icstrw/CmqA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "cjs-module-lexer": "^2.2.0",
+        "es-module-lexer": "^2.2.0",
+        "module-details-from-path": "^1.0.4"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
@@ -858,6 +1292,21 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
+      }
+    },
+    "node_modules/jpeg-js": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/jpeg-js/-/jpeg-js-0.4.4.tgz",
+      "integrity": "sha512-WZzeDOEtTOBK4Mdsar0IqEU5sMr3vSV2RqkAIzUEV2BHnUfKGyswWFPFwK5EeDo93K3FohSHbLAjj0s1Wzd+dg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/js-image-generator": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/js-image-generator/-/js-image-generator-1.0.4.tgz",
+      "integrity": "sha512-ckb7kyVojGAnArouVR+5lBIuwU1fcrn7E/YYSd0FK7oIngAkMmRvHASLro9Zt5SQdWToaI66NybG+OGxPw/HlQ==",
+      "license": "ISC",
+      "dependencies": {
+        "jpeg-js": "^0.4.2"
       }
     },
     "node_modules/jsonwebtoken": {
@@ -1039,6 +1488,12 @@
         "node": "*"
       }
     },
+    "node_modules/module-details-from-path": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/module-details-from-path/-/module-details-from-path-1.0.4.tgz",
+      "integrity": "sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==",
+      "license": "MIT"
+    },
     "node_modules/ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
@@ -1132,6 +1587,15 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/parse-gitignore": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/parse-gitignore/-/parse-gitignore-2.0.0.tgz",
+      "integrity": "sha512-RmVuCHWsfu0QPNW+mraxh/xjQVw/lhUCUru8Zni3Ctq3AoMhpDTq0OVdKS6iesd6Kqb7viCV3isAL43dciOSog==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/parseurl": {
@@ -1268,6 +1732,42 @@
         "node": ">=8.10.0"
       }
     },
+    "node_modules/require-in-the-middle": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-8.0.1.tgz",
+      "integrity": "sha512-QT7FVMXfWOYFbeRBF6nu+I6tr2Tf3u0q8RIEjNob/heKY/nh7drD/k7eeMFmSQgnTtCzLDcCu/XEnpW2wk4xCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.5",
+        "module-details-from-path": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=9.3.0 || >=8.10.0 <9.0.0"
+      }
+    },
+    "node_modules/require-in-the-middle/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/require-in-the-middle/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
     "node_modules/requires-port": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
@@ -1365,6 +1865,15 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/serverless-http": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/serverless-http/-/serverless-http-4.0.0.tgz",
+      "integrity": "sha512-KKl9h1+VApX9y2vHsVMogf906UXBwO3FDYiWPzqS0mCjEEx4Sx91JrssbWA7RN43HBuxrtoh8MkocZPvjyGnLg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0"
       }
     },
     "node_modules/setprototypeof": {
@@ -1477,6 +1986,21 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/stubborn-fs": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/stubborn-fs/-/stubborn-fs-2.0.0.tgz",
+      "integrity": "sha512-Y0AvSwDw8y+nlSNFXMm2g6L51rBGdAQT20J3YSOqxC53Lo3bjWRtr2BKcfYoAf352WYpsZSTURrA0tqhfgudPA==",
+      "license": "MIT",
+      "dependencies": {
+        "stubborn-utils": "^1.0.1"
+      }
+    },
+    "node_modules/stubborn-utils": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/stubborn-utils/-/stubborn-utils-1.0.2.tgz",
+      "integrity": "sha512-zOh9jPYI+xrNOyisSelgym4tolKTJCQd5GBhK0+0xJvcYDcwlOoxF/rnFKQ2KRZknXSG9jWAp66fwP6AxN9STg==",
+      "license": "MIT"
+    },
     "node_modules/supports-color": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
@@ -1488,6 +2012,24 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/tmp": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+      "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "node_modules/tmp-promise": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/tmp-promise/-/tmp-promise-3.0.3.tgz",
+      "integrity": "sha512-RwM7MoPojPxsOBYnyd2hy0bxtIlVrihNs9pj5SUvY8Zz1sQcQG2tG1hSr8PDxfgEB8RNKDhqbIlroIarSNDNsQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tmp": "^0.2.0"
       }
     },
     "node_modules/to-regex-range": {
@@ -1522,6 +2064,12 @@
         "nodetouch": "bin/nodetouch.js"
       }
     },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
     "node_modules/twilio": {
       "version": "3.84.1",
       "resolved": "https://registry.npmjs.org/twilio/-/twilio-3.84.1.tgz",
@@ -1551,6 +2099,18 @@
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.14.8"
+      }
+    },
+    "node_modules/type-fest": {
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/type-is": {
@@ -1592,6 +2152,12 @@
         "requires-port": "^1.0.0"
       }
     },
+    "node_modules/urlpattern-polyfill": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/urlpattern-polyfill/-/urlpattern-polyfill-10.1.0.tgz",
+      "integrity": "sha512-IGjKp/o0NL3Bso1PymYURCJxMPNAf/ILOpendP9f5B6e1rTJgdgiOvgfoT8VxCAdY+Wisb9uhGaJJf3yZ2V9nw==",
+      "license": "MIT"
+    },
     "node_modules/utils-merge": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
@@ -1615,6 +2181,12 @@
       "resolved": "https://registry.npmjs.org/weak-map/-/weak-map-1.0.8.tgz",
       "integrity": "sha512-lNR9aAefbGPpHO7AEnY0hCFjz1eTkWCXYvkTRrTHs9qv8zJp+SkVYpzfLIFXQQiG3tVvbNFQgVg2bQS8YGgxyw==",
       "license": "Apache-2.0"
+    },
+    "node_modules/when-exit": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/when-exit/-/when-exit-2.1.5.tgz",
+      "integrity": "sha512-VGkKJ564kzt6Ms1dbgPP/yuIoQCrsFAnRbptpC5wOEsDaNsbCB2bnfnaA8i/vRs5tjUSEOtIuvl9/MyVsvQZCg==",
+      "license": "MIT"
     },
     "node_modules/xmlbuilder": {
       "version": "13.0.2",

--- a/package.json
+++ b/package.json
@@ -12,11 +12,13 @@
     "node": ">=18"
   },
   "dependencies": {
-    "express": "^4.18.2",
+    "@netlify/blobs": "^10.7.9",
     "axios": "^1.4.0",
+    "dotenv": "^16.0.3",
+    "express": "^4.18.2",
     "form-data": "^4.0.0",
-    "twilio": "^3.83.0",
-    "dotenv": "^16.0.3"
+    "serverless-http": "^4.0.0",
+    "twilio": "^3.83.0"
   },
   "devDependencies": {
     "nodemon": "^2.0.22"

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Josephine Transcription Service</title>
+</head>
+<body>
+  <p>Josephine Transcription Service is running!</p>
+</body>
+</html>

--- a/src/app.js
+++ b/src/app.js
@@ -1,0 +1,37 @@
+// src/app.js - Express app definition (no listener)
+// Used by src/index.js (Heroku/local server) and netlify/functions (serverless)
+require('dotenv').config();
+const express = require('express');
+const app = express();
+const routes = require('./routes');
+const { logDetails } = require('./utils/logging-utils');
+
+// Middleware
+app.use(express.json());
+app.use(express.urlencoded({ extended: true }));
+
+// Debug middleware
+app.use((req, res, next) => {
+  logDetails('Request received', {
+    method: req.method,
+    path: req.path,
+    query: req.query,
+    contentType: req.get('Content-Type')
+  });
+  next();
+});
+
+// Use routes
+app.use('/', routes);
+
+// Global error handler
+app.use((err, req, res, next) => {
+  console.error('Unhandled error:', err);
+  res.status(500).json({
+    status: 'error',
+    message: 'Internal server error',
+    error: err.message
+  });
+});
+
+module.exports = app;

--- a/src/controllers/transcription.js
+++ b/src/controllers/transcription.js
@@ -1,10 +1,6 @@
 // src/controllers/transcription.js
-const { getUserLanguage, getLocalizedMessage, exceedsWordLimit } = require('../helpers/localization');
-const { generateSummary } = require('../helpers/transcription');
-const { downloadAudio, prepareFormData } = require('../services/audio-service');
-const { transcribeAudio } = require('../services/transcription-service');
-const { checkContentModeration } = require('../services/moderation-service');
-const { splitLongMessage, sendMessages } = require('../services/messaging-service');
+const { getUserLanguage, getLocalizedMessage } = require('../helpers/localization');
+const { processVoiceNote } = require('../core/voice-note-pipeline');
 const { formatTestResponse, formatErrorResponse, formatSuccessResponse } = require('../utils/response-formatter');
 const { logDetails } = require('../utils/logging-utils');
 
@@ -17,16 +13,16 @@ async function handleNonAudioMedia(req, res) {
   const toPhone = event.To || process.env.TWILIO_PHONE_NUMBER;
   const userLang = getUserLanguage(userPhone);
   const twilioClient = req.twilioClient;
-  
+
   const sendAudioMessage = await getLocalizedMessage('sendAudio', userLang);
-  
+
   if (twilioClient.isAvailable()) {
     await twilioClient.sendMessage({
       body: sendAudioMessage,
       from: toPhone,
       to: userPhone
     });
-    
+
     // For test mode, return test results instead of XML
     if (req.isTestMode) {
       return formatTestResponse(res, {
@@ -48,184 +44,85 @@ async function handleNonAudioMedia(req, res) {
 }
 
 /**
- * Handle transcription of voice note
+ * Handle transcription of voice note.
+ * The pipeline itself lives in src/core/voice-note-pipeline.js (shared
+ * with the Netlify background function); this wrapper only maps the
+ * pipeline result onto the same HTTP responses as before.
  */
 async function handleVoiceNote(req, res) {
-  const event = req.body || {};
-  const userPhone = event.From || 'unknown';
-  const toPhone = event.To || process.env.TWILIO_PHONE_NUMBER;
-  const userLang = getUserLanguage(userPhone);
   const twilioClient = req.twilioClient;
-  const mediaContentType = event.MediaContentType0;
-  const mediaUrl = event.MediaUrl0;
-  
-  logDetails('Processing voice note...');
-  
-  try {
-    // Prepare authentication headers for audio download
-    const authHeaders = {};
-    if (process.env.ACCOUNT_SID && process.env.AUTH_TOKEN) {
-      const authHeader = 'Basic ' + Buffer.from(`${process.env.ACCOUNT_SID}:${process.env.AUTH_TOKEN}`).toString('base64');
-      authHeaders['Authorization'] = authHeader;
-    }
-    
-    // Download audio file
-    const { data: audioData } = await downloadAudio(mediaUrl, authHeaders, req);
-    
-    // Prepare form data for Whisper API
-    const formData = prepareFormData(audioData, mediaContentType);
-    
-    // Transcribe the audio
-    const transcription = await transcribeAudio(formData, process.env.OPENAI_API_KEY, req);
-    
-    // Check for prohibited content
-    const moderationResult = await checkContentModeration(transcription, process.env.OPENAI_API_KEY);
-    if (moderationResult.flagged) {
-      logDetails('Content moderation flagged this transcription', moderationResult);
-      
-      // Get a localized message about content violation
-      const contentViolationMessage = await getLocalizedMessage('contentViolation', userLang);
-      
-      if (twilioClient.isAvailable()) {
-        await twilioClient.sendMessage({
-          body: contentViolationMessage,
-          from: toPhone,
-          to: userPhone
-        });
-        
-        // For test mode, return test results instead of XML
+
+  // An Express req is a valid pipeline context: it carries
+  // body, isTestMode, testResults and twilioClient.
+  const result = await processVoiceNote(req);
+
+  const sendXML = () => {
+    const xmlResponse = twilioClient.generateXMLResponse('<Response></Response>');
+    res.set('Content-Type', 'text/xml');
+    return res.send(xmlResponse);
+  };
+
+  switch (result.flow) {
+    case 'content_violation':
+      if (result.twilioAvailable) {
         if (req.isTestMode) {
           return formatTestResponse(res, {
             flow: 'content_violation',
-            message: contentViolationMessage,
-            moderation: {
-              flagged: true,
-              categories: moderationResult.categories
-            },
+            message: result.message,
+            moderation: result.moderation,
             testResults: twilioClient.getTestResults()
           });
-        } else {
-          // Generate XML response for Twilio
-          const xmlResponse = twilioClient.generateXMLResponse('<Response></Response>');
-          res.set('Content-Type', 'text/xml');
-          return res.send(xmlResponse);
         }
-      } else {
-        return formatErrorResponse(res, 403, contentViolationMessage, {
-          flow: 'content_violation',
-          moderation: {
-            flagged: true,
-            categories: moderationResult.categories
-          }
-        });
+        return sendXML();
       }
-    }
+      return formatErrorResponse(res, 403, result.message, {
+        flow: 'content_violation',
+        moderation: result.moderation
+      });
 
-    // Generate summary for long transcriptions
-let summary = null;
-// Special handling for test mode with longTranscription=true
-if (req.isTestMode && req.body && req.body.longTranscription === 'true') {
-  logDetails('Forcing summary generation for test with longTranscription=true');
-  summary = "This is a test summary of the transcription. The main points discussed include testing functionality, mock data generation, and verification of the summary feature.";
-} else if (exceedsWordLimit(transcription, 150)) {
-  logDetails('Generating summary for long transcription');
-  summary = await generateSummary(transcription, userLang);
-  logDetails('Summary generated', { summary });
-}
-
-    // Prepare the final message
-    let finalMessage = '';
-    if (summary) {
-      const summaryLabel = await getLocalizedMessage('longMessage', userLang);
-      finalMessage += `${summaryLabel.trim()} ${summary}\n\n`;
-    }
-    
-    const transcriptionLabel = await getLocalizedMessage('transcription', userLang);
-    // Make sure we don't add an extra emoji here - just use what's in the label
-    finalMessage += `${transcriptionLabel.trim()}\n${transcription}`;
-    
-    // Split the message if needed
-    const messageParts = splitLongMessage(finalMessage);
-    
-    // First send the message, then finish the response
-    if (twilioClient.isAvailable()) {
-      try {
-        // Send the messages
-        await sendMessages(twilioClient, messageParts, userPhone, toPhone);
-        
-        // For test mode, return test results instead of XML
+    case 'successful_transcription':
+      if (result.twilioAvailable) {
         if (req.isTestMode) {
           return formatTestResponse(res, {
             flow: 'successful_transcription',
-            summary: summary,
-            transcription: transcription,
-            message: finalMessage,
+            summary: result.summary,
+            transcription: result.transcription,
+            message: result.message,
             testResults: twilioClient.getTestResults()
           });
-        } else {
-          // Generate XML response for Twilio
-          const xmlResponse = twilioClient.generateXMLResponse('<Response></Response>');
-          res.set('Content-Type', 'text/xml');
-          return res.send(xmlResponse);
         }
-      } catch (twilioError) {
-        logDetails('Error sending message via Twilio:', twilioError);
-        return formatErrorResponse(res, 500, 'Failed to send transcription', {
-          flow: 'twilio_error',
-          error: twilioError.message
-        });
+        return sendXML();
       }
-    } else {
-      logDetails('No Twilio client - returning JSON response');
-
       return formatSuccessResponse(res, {
         flow: 'successful_transcription',
-        summary: summary,
-        transcription: transcription,
-        message: finalMessage
+        summary: result.summary,
+        transcription: result.transcription,
+        message: result.message
       });
-    }
-  } catch (processingError) {
-    logDetails('ERROR PROCESSING AUDIO:', processingError);
-    
-    // Determine specific error type
-    let errorMessage;
-    
-    if (processingError.response && processingError.response.status === 429) {
-      errorMessage = await getLocalizedMessage('rateLimited', userLang);
-    } else if (processingError.code === 'ECONNABORTED' || processingError.message.includes('timeout')) {
-      errorMessage = await getLocalizedMessage('processingTimeout', userLang);
-    } else {
-      errorMessage = await getLocalizedMessage('apiError', userLang);
-    }
-    
-    if (twilioClient.isAvailable()) {
-      await twilioClient.sendMessage({
-        body: errorMessage,
-        from: toPhone,
-        to: userPhone
+
+    case 'twilio_error':
+      return formatErrorResponse(res, 500, 'Failed to send transcription', {
+        flow: 'twilio_error',
+        error: result.error
       });
-      
-      // For test mode, return test results instead of XML
-      if (req.isTestMode) {
-        return formatTestResponse(res, {
-          flow: 'processing_error',
-          message: errorMessage,
-          error: processingError.message,
-          testResults: twilioClient.getTestResults()
-        });
-      } else {
-        // Generate XML response for Twilio
-        const xmlResponse = twilioClient.generateXMLResponse('<Response></Response>');
-        res.set('Content-Type', 'text/xml'); 
-        return res.send(xmlResponse);
+
+    case 'processing_error':
+    default:
+      if (result.twilioAvailable) {
+        if (req.isTestMode) {
+          return formatTestResponse(res, {
+            flow: 'processing_error',
+            message: result.message,
+            error: result.error,
+            testResults: twilioClient.getTestResults()
+          });
+        }
+        return sendXML();
       }
-    } else {
-      return formatErrorResponse(res, 500, errorMessage, {
+      return formatErrorResponse(res, 500, result.message, {
         flow: 'processing_error',
-        error: processingError.message
+        error: result.error
       });
-    }
   }
 }
 

--- a/src/core/voice-note-pipeline.js
+++ b/src/core/voice-note-pipeline.js
@@ -1,0 +1,193 @@
+// src/core/voice-note-pipeline.js
+// The voice-note transcription pipeline, decoupled from Express.
+// Callable from the Express controller (Heroku/local) and from the
+// Netlify background function. `context` is a req-like object:
+//   { body, isTestMode, testResults, twilioClient }
+// All user-facing messages (including localized errors) are sent from
+// here via the provided twilioClient; the returned result object only
+// describes what happened so callers can shape their HTTP response.
+const { getUserLanguage, getLocalizedMessage, exceedsWordLimit } = require('../helpers/localization');
+const { generateSummary } = require('../helpers/transcription');
+const { downloadAudio, prepareFormData } = require('../services/audio-service');
+const { transcribeAudio } = require('../services/transcription-service');
+const { checkContentModeration } = require('../services/moderation-service');
+const { splitLongMessage, sendMessages } = require('../services/messaging-service');
+const { logDetails } = require('../utils/logging-utils');
+
+/**
+ * Process a voice note end-to-end: download, transcribe, moderate,
+ * summarize (if long), and send the result to the user.
+ *
+ * Returns a result object:
+ *   { flow, twilioAvailable, message, transcription?, summary?,
+ *     moderation?, error?, statusCode? }
+ * where flow is one of:
+ *   'successful_transcription' | 'content_violation' |
+ *   'processing_error' | 'twilio_error'
+ */
+async function processVoiceNote(context) {
+  const event = context.body || {};
+  const userPhone = event.From || 'unknown';
+  const toPhone = event.To || process.env.TWILIO_PHONE_NUMBER;
+  const userLang = getUserLanguage(userPhone);
+  const twilioClient = context.twilioClient;
+  const mediaContentType = event.MediaContentType0;
+  const mediaUrl = event.MediaUrl0;
+
+  logDetails('Processing voice note...');
+
+  try {
+    // Prepare authentication headers for audio download
+    const authHeaders = {};
+    if (process.env.ACCOUNT_SID && process.env.AUTH_TOKEN) {
+      const authHeader = 'Basic ' + Buffer.from(`${process.env.ACCOUNT_SID}:${process.env.AUTH_TOKEN}`).toString('base64');
+      authHeaders['Authorization'] = authHeader;
+    }
+
+    // Download audio file
+    const { data: audioData } = await downloadAudio(mediaUrl, authHeaders, context);
+
+    // Prepare form data for Whisper API
+    const formData = prepareFormData(audioData, mediaContentType);
+
+    // Transcribe the audio
+    const transcription = await transcribeAudio(formData, process.env.OPENAI_API_KEY, context);
+
+    // Check for prohibited content
+    const moderationResult = await checkContentModeration(transcription, process.env.OPENAI_API_KEY);
+    if (moderationResult.flagged) {
+      logDetails('Content moderation flagged this transcription', moderationResult);
+
+      // Get a localized message about content violation
+      const contentViolationMessage = await getLocalizedMessage('contentViolation', userLang);
+
+      if (twilioClient.isAvailable()) {
+        await twilioClient.sendMessage({
+          body: contentViolationMessage,
+          from: toPhone,
+          to: userPhone
+        });
+
+        return {
+          flow: 'content_violation',
+          twilioAvailable: true,
+          message: contentViolationMessage,
+          moderation: {
+            flagged: true,
+            categories: moderationResult.categories
+          }
+        };
+      }
+
+      return {
+        flow: 'content_violation',
+        twilioAvailable: false,
+        statusCode: 403,
+        message: contentViolationMessage,
+        moderation: {
+          flagged: true,
+          categories: moderationResult.categories
+        }
+      };
+    }
+
+    // Generate summary for long transcriptions
+    let summary = null;
+    // Special handling for test mode with longTranscription=true
+    if (context.isTestMode && event.longTranscription === 'true') {
+      logDetails('Forcing summary generation for test with longTranscription=true');
+      summary = "This is a test summary of the transcription. The main points discussed include testing functionality, mock data generation, and verification of the summary feature.";
+    } else if (exceedsWordLimit(transcription, 150)) {
+      logDetails('Generating summary for long transcription');
+      summary = await generateSummary(transcription, userLang);
+      logDetails('Summary generated', { summary });
+    }
+
+    // Prepare the final message
+    let finalMessage = '';
+    if (summary) {
+      const summaryLabel = await getLocalizedMessage('longMessage', userLang);
+      finalMessage += `${summaryLabel.trim()} ${summary}\n\n`;
+    }
+
+    const transcriptionLabel = await getLocalizedMessage('transcription', userLang);
+    // Make sure we don't add an extra emoji here - just use what's in the label
+    finalMessage += `${transcriptionLabel.trim()}\n${transcription}`;
+
+    // Split the message if needed
+    const messageParts = splitLongMessage(finalMessage);
+
+    if (twilioClient.isAvailable()) {
+      try {
+        // Send the messages
+        await sendMessages(twilioClient, messageParts, userPhone, toPhone);
+
+        return {
+          flow: 'successful_transcription',
+          twilioAvailable: true,
+          summary: summary,
+          transcription: transcription,
+          message: finalMessage
+        };
+      } catch (twilioError) {
+        logDetails('Error sending message via Twilio:', twilioError);
+        return {
+          flow: 'twilio_error',
+          twilioAvailable: true,
+          statusCode: 500,
+          message: 'Failed to send transcription',
+          error: twilioError.message
+        };
+      }
+    }
+
+    logDetails('No Twilio client - returning JSON response');
+    return {
+      flow: 'successful_transcription',
+      twilioAvailable: false,
+      summary: summary,
+      transcription: transcription,
+      message: finalMessage
+    };
+  } catch (processingError) {
+    logDetails('ERROR PROCESSING AUDIO:', processingError);
+
+    // Determine specific error type
+    let errorMessage;
+
+    if (processingError.response && processingError.response.status === 429) {
+      errorMessage = await getLocalizedMessage('rateLimited', userLang);
+    } else if (processingError.code === 'ECONNABORTED' || processingError.message.includes('timeout')) {
+      errorMessage = await getLocalizedMessage('processingTimeout', userLang);
+    } else {
+      errorMessage = await getLocalizedMessage('apiError', userLang);
+    }
+
+    if (twilioClient.isAvailable()) {
+      await twilioClient.sendMessage({
+        body: errorMessage,
+        from: toPhone,
+        to: userPhone
+      });
+
+      return {
+        flow: 'processing_error',
+        twilioAvailable: true,
+        message: errorMessage,
+        error: processingError.message
+      };
+    }
+
+    return {
+      flow: 'processing_error',
+      twilioAvailable: false,
+      statusCode: 500,
+      message: errorMessage,
+      error: processingError.message
+    };
+  }
+}
+
+module.exports = {
+  processVoiceNote
+};

--- a/src/index.js
+++ b/src/index.js
@@ -1,37 +1,5 @@
-// src/index.js
-require('dotenv').config();
-const express = require('express');
-const app = express();
-const routes = require('./routes');
-const { logDetails } = require('./utils/logging-utils');
-
-// Middleware
-app.use(express.json());
-app.use(express.urlencoded({ extended: true }));
-
-// Debug middleware
-app.use((req, res, next) => {
-  logDetails('Request received', {
-    method: req.method,
-    path: req.path,
-    query: req.query,
-    contentType: req.get('Content-Type')
-  });
-  next();
-});
-
-// Use routes
-app.use('/', routes);
-
-// Global error handler
-app.use((err, req, res, next) => {
-  console.error('Unhandled error:', err);
-  res.status(500).json({
-    status: 'error',
-    message: 'Internal server error',
-    error: err.message
-  });
-});
+// src/index.js - Server entry point (Heroku / local dev)
+const app = require('./app');
 
 // Start the server
 const PORT = process.env.PORT || 8080;


### PR DESCRIPTION
Enables running Josephine on Netlify while keeping Heroku fully working for a **parallel-run cutover** (rollback = repoint the Twilio webhook URL).

## Why the architecture change
Netlify sync functions time out at 10s; the pipeline takes 20–40s. So: the sync function acks Twilio instantly with empty TwiML and hands the pipeline to a **background function** (15-min budget). The user's reply was always sent via Twilio REST — never TwiML — so **UX is unchanged**.

## Reliability additions (beyond parity with Heroku)
- **Twilio signature validation** — closes an existing hole: any unauthenticated POST could previously burn OpenAI credits
- **MessageSid dedup** (Netlify Blobs, strong consistency, fail-open) — a Twilio webhook retry can never cause a duplicate transcription / double spend
- **No silent failures** — handled errors message the user with the existing localized texts; failed Twilio sends throw so Netlify auto-retries (1 min / 2 min)
- **Dispatch failure → 500 + marker rollback** so Twilio's own retry re-queues the job

## Refactor (behavior-preserving)
- `src/index.js` → `src/app.js` (app) + listener; `npm start` unchanged
- `handleVoiceNote` pipeline → `src/core/voice-note-pipeline.js` (Express-free, shared); controller is now a thin response mapper
- All services/helpers untouched

## Verified
- 16/16 unit checks on the handlers: signature accept+reject (independently computed HMAC), dispatch handshake incl. payload/token, rollback on failed dispatch, background token auth, pipeline error classification, malformed payload rejection
- Live via `netlify functions:serve`: esbuild bundling, Express delegation, background queueing + execution
- Full Express regression suite: welcome / language / voice note / long summary / non-audio all byte-identical pre/post refactor

## Cutover runbook (after merge)
1. Netlify: connect repo → build settings come from `netlify.toml`
2. Env vars in Netlify UI: `OPENAI_API_KEY`, `ACCOUNT_SID`, `AUTH_TOKEN`, `TWILIO_PHONE_NUMBER`, **`INTERNAL_API_SECRET`** (random 32+ chars), **`TWILIO_WEBHOOK_URL`** = `https://<site>/transcribe`
3. Verify with test-mode curls against `https://<site>/transcribe`
4. Twilio Console → WhatsApp sender → *When a message comes in* → `https://<site>/transcribe` (keep the old Heroku URL noted for rollback)
5. Send a real voice note; watch Netlify function logs
6. Keep Heroku running ~1 week, then decommission

🤖 Generated with [Claude Code](https://claude.com/claude-code)