### PR TITLE
Log diagnostic detail on Twilio signature rejection

### DIFF
--- a/netlify/functions/transcribe.js
+++ b/netlify/functions/transcribe.js
@@ -61,7 +61,19 @@ exports.handler = async (event, context) => {
     const url = process.env.TWILIO_WEBHOOK_URL || event.rawUrl;
     const valid = twilio.validateRequest(process.env.AUTH_TOKEN || '', signature, url, params);
     if (!valid) {
-      logDetails('Rejected request with invalid Twilio signature', { url });
+      // Log enough detail to distinguish a URL mismatch from a token
+      // mismatch without exposing secrets (signature prefix only).
+      logDetails('Rejected request with invalid Twilio signature', {
+        urlUsed: url,
+        urlSource: process.env.TWILIO_WEBHOOK_URL ? 'TWILIO_WEBHOOK_URL env' : 'event.rawUrl fallback',
+        rawUrl: event.rawUrl,
+        signatureHeaderPresent: !!signature,
+        signaturePrefix: signature ? signature.slice(0, 6) : null,
+        authTokenPresent: !!process.env.AUTH_TOKEN,
+        authTokenLength: (process.env.AUTH_TOKEN || '').length,
+        paramCount: Object.keys(params).length,
+        messageSid: params.MessageSid
+      });
       return { statusCode: 403, body: 'Invalid Twilio signature' };
     }
   }


### PR DESCRIPTION
First real Twilio webhook was rejected 403 by signature validation. Local forensics (reconstructing the exact request from the Twilio debugger) proved parsing and the validator round-trip are correct, so the cause is config: either the TWILIO_WEBHOOK_URL value or AUTH_TOKEN being a secondary token. This adds a detailed (secret-free) log line on rejection so the next attempt pinpoints which.

🤖 Generated with [Claude Code](https://claude.com/claude-code)