### PR TITLE
Fix Blobs connection in Lambda-style functions; parallelize moderation+summary

### DIFF
--- a/netlify/functions/lib/shared.js
+++ b/netlify/functions/lib/shared.js
@@ -1,6 +1,6 @@
 // netlify/functions/lib/shared.js
 // Small helpers shared by the sync webhook and the background worker.
-const { getStore } = require('@netlify/blobs');
+const { getStore, connectLambda } = require('@netlify/blobs');
 
 // The empty TwiML ack Twilio expects (matches the Express app's response).
 const EMPTY_TWIML = '<Response></Response>';
@@ -8,7 +8,16 @@ const EMPTY_TWIML = '<Response></Response>';
 // Blobs store used for MessageSid idempotency. Strong consistency so a
 // Twilio webhook retry (seconds later) sees the marker immediately.
 // Marker lifecycle: dispatched -> processing -> done | failed | retrying
-function getProcessedStore() {
+//
+// These functions use the legacy Lambda-style handler API, where the
+// Blobs environment context is delivered on the event rather than
+// injected automatically — connectLambda(event) wires it up. Without it
+// getStore() throws "environment has not been configured" (observed in
+// production 2026-07-11) and dedup silently fail-opens.
+function getProcessedStore(event) {
+  if (event) {
+    connectLambda(event);
+  }
   return getStore({ name: 'processed-messages', consistency: 'strong' });
 }
 

--- a/netlify/functions/transcribe-background.js
+++ b/netlify/functions/transcribe-background.js
@@ -40,7 +40,7 @@ exports.handler = async (event) => {
   // Idempotency check — fail-open (a Blobs hiccup must not drop the job).
   let store = null;
   try {
-    store = getProcessedStore();
+    store = getProcessedStore(event);
     const marker = await store.get(sid, { type: 'json' });
     if (marker && (marker.status === 'done' || marker.status === 'failed')) {
       logDetails(`Skipping ${sid}: already ${marker.status}`);

--- a/netlify/functions/transcribe.js
+++ b/netlify/functions/transcribe.js
@@ -91,7 +91,7 @@ exports.handler = async (event, context) => {
     // Dedup is fail-open: a Blobs hiccup must never block a transcription.
     let store = null;
     try {
-      store = getProcessedStore();
+      store = getProcessedStore(event);
       const existing = await store.get(params.MessageSid, { type: 'json' });
       if (existing) {
         logDetails(`Duplicate webhook for ${params.MessageSid} (status=${existing.status}) — acking without re-dispatch`);

--- a/src/core/voice-note-pipeline.js
+++ b/src/core/voice-note-pipeline.js
@@ -53,8 +53,31 @@ async function processVoiceNote(context) {
     // Transcribe the audio
     const transcription = await transcribeAudio(formData, process.env.OPENAI_API_KEY, context);
 
+    // Moderation and summary generation both depend only on the
+    // transcript, so run them concurrently (saves the moderation time
+    // on long notes). The summary is simply discarded if moderation
+    // flags the content — rare enough that the wasted call is a fair
+    // trade for the latency win on every clean long note.
+    const summaryPromise = (async () => {
+      // Special handling for test mode with longTranscription=true
+      if (context.isTestMode && event.longTranscription === 'true') {
+        logDetails('Forcing summary generation for test with longTranscription=true');
+        return "This is a test summary of the transcription. The main points discussed include testing functionality, mock data generation, and verification of the summary feature.";
+      }
+      if (exceedsWordLimit(transcription, 150)) {
+        logDetails('Generating summary for long transcription');
+        const generated = await generateSummary(transcription, userLang);
+        logDetails('Summary generated', { summary: generated });
+        return generated;
+      }
+      return null;
+    })();
+
     // Check for prohibited content
-    const moderationResult = await checkContentModeration(transcription, process.env.OPENAI_API_KEY);
+    const [moderationResult, summary] = await Promise.all([
+      checkContentModeration(transcription, process.env.OPENAI_API_KEY),
+      summaryPromise
+    ]);
     if (moderationResult.flagged) {
       logDetails('Content moderation flagged this transcription', moderationResult);
 
@@ -89,18 +112,6 @@ async function processVoiceNote(context) {
           categories: moderationResult.categories
         }
       };
-    }
-
-    // Generate summary for long transcriptions
-    let summary = null;
-    // Special handling for test mode with longTranscription=true
-    if (context.isTestMode && event.longTranscription === 'true') {
-      logDetails('Forcing summary generation for test with longTranscription=true');
-      summary = "This is a test summary of the transcription. The main points discussed include testing functionality, mock data generation, and verification of the summary feature.";
-    } else if (exceedsWordLimit(transcription, 150)) {
-      logDetails('Generating summary for long transcription');
-      summary = await generateSummary(transcription, userLang);
-      logDetails('Summary generated', { summary });
     }
 
     // Prepare the final message


### PR DESCRIPTION
## Bug fix (found via production logs)
The background function logged `The environment has not been configured to use Netlify Blobs` — meaning **MessageSid dedup was silently fail-opening on every request** (messages still processed, but no duplicate protection). Legacy Lambda-style handlers need `connectLambda(event)` before `getStore()`; only v2 functions get automatic context injection. Fixed in `lib/shared.js` for both functions.

## Perf (data-driven from the same log)
Real timing showed: transcription 1,871ms (65%), moderation ~525ms (18%), download 246ms, send 213ms. For long notes, moderation + summary ran sequentially despite both needing only the transcript — now `Promise.all`, saving ~0.5s on every clean long note. Flagged long notes waste one summary call (rare, acceptable).

## Verified
- 16/16 function harness checks
- Express regression: short note keeps the `summary: null` contract, long note still generates a summary

🤖 Generated with [Claude Code](https://claude.com/claude-code)