### PR TITLE
Migrate background function to v2 API for working strong-consistency dedup

### DIFF
--- a/netlify/functions/lib/shared.js
+++ b/netlify/functions/lib/shared.js
@@ -1,24 +1,26 @@
 // netlify/functions/lib/shared.js
-// Small helpers shared by the sync webhook and the background worker.
+// Helpers for the sync webhook (legacy Lambda-style handler).
 const { getStore, connectLambda } = require('@netlify/blobs');
 
 // The empty TwiML ack Twilio expects (matches the Express app's response).
 const EMPTY_TWIML = '<Response></Response>';
 
-// Blobs store used for MessageSid idempotency. Strong consistency so a
-// Twilio webhook retry (seconds later) sees the marker immediately.
+// Blobs store used for MessageSid idempotency.
 // Marker lifecycle: dispatched -> processing -> done | failed | retrying
 //
-// These functions use the legacy Lambda-style handler API, where the
-// Blobs environment context is delivered on the event rather than
-// injected automatically — connectLambda(event) wires it up. Without it
-// getStore() throws "environment has not been configured" (observed in
-// production 2026-07-11) and dedup silently fail-opens.
+// The sync webhook runs as a legacy Lambda-style function (serverless-http
+// needs Lambda events), where connectLambda(event) provides only the
+// edgeURL + token — never the uncachedEdgeURL that strong-consistency
+// reads require (verified in @netlify/blobs source; strong reads throw).
+// So this store reads at EVENTUAL consistency: a best-effort fast-path
+// that absorbs most Twilio webhook retries. The authoritative dedup gate
+// is the background function (v2 API, automatic full context, strong
+// reads) — anything that slips past this check is caught there.
 function getProcessedStore(event) {
   if (event) {
     connectLambda(event);
   }
-  return getStore({ name: 'processed-messages', consistency: 'strong' });
+  return getStore({ name: 'processed-messages', consistency: 'eventual' });
 }
 
 module.exports = {

--- a/netlify/functions/transcribe-background.mjs
+++ b/netlify/functions/transcribe-background.mjs
@@ -1,50 +1,57 @@
-// netlify/functions/transcribe-background.js
+// netlify/functions/transcribe-background.mjs
 // Background worker (the "-background" suffix gives it a 15-minute budget;
 // Netlify acks invocations with 202 immediately and auto-retries failed
 // runs after 1 min, then 2 min).
 //
+// Uses the modern (v2) function API on purpose: v2 functions receive the
+// full Netlify Blobs context automatically — including the uncachedEdgeURL
+// required for strong-consistency reads, which the legacy Lambda-style
+// context (connectLambda) never provides. This function is the
+// authoritative dedup gate, so it must have strong reads; the sync
+// webhook's best-effort check runs at eventual consistency.
+//
 // Runs the full voice-note pipeline via src/core/voice-note-pipeline.js —
-// download, Whisper, moderation, optional summary, Twilio sends. On any
-// handled failure the pipeline itself messages the user with the existing
-// localized error text, so nothing fails silently.
+// download, transcription, moderation, optional summary, Twilio sends. On
+// any handled failure the pipeline itself messages the user with the
+// existing localized error text, so nothing fails silently.
 //
 // Idempotency marker (Netlify Blobs, key = MessageSid):
 //   done / failed  -> terminal, exit without reprocessing
 //   anything else  -> process (covers first delivery, crash retries, and
 //                     'retrying' set after a failed Twilio send)
-const { TwilioClientWrapper } = require('../../src/services/twilio-service');
-const { processVoiceNote } = require('../../src/core/voice-note-pipeline');
-const { logDetails } = require('../../src/utils/logging-utils');
-const { getProcessedStore } = require('./lib/shared');
+import { getStore } from '@netlify/blobs';
+import { TwilioClientWrapper } from '../../src/services/twilio-service.js';
+import { processVoiceNote } from '../../src/core/voice-note-pipeline.js';
+import { logDetails } from '../../src/utils/logging-utils.js';
 
-exports.handler = async (event) => {
+export default async (req) => {
   // Only our own sync function may invoke this endpoint.
-  const token = (event.headers && (event.headers['x-internal-token'] || event.headers['X-Internal-Token'])) || '';
+  const token = req.headers.get('x-internal-token') || '';
   if (!process.env.INTERNAL_API_SECRET || token !== process.env.INTERNAL_API_SECRET) {
     logDetails('Rejected background invocation with missing/invalid internal token');
-    return { statusCode: 401, body: 'Unauthorized' };
+    return new Response('Unauthorized', { status: 401 });
   }
 
   let params;
   try {
-    params = JSON.parse(event.body || '{}');
+    params = await req.json();
   } catch (e) {
-    return { statusCode: 400, body: 'Invalid JSON payload' };
+    return new Response('Invalid JSON payload', { status: 400 });
   }
 
   const sid = params.MessageSid;
   if (!sid || !params.MediaUrl0) {
-    return { statusCode: 400, body: 'Missing MessageSid or MediaUrl0' };
+    return new Response('Missing MessageSid or MediaUrl0', { status: 400 });
   }
 
   // Idempotency check — fail-open (a Blobs hiccup must not drop the job).
   let store = null;
   try {
-    store = getProcessedStore(event);
+    store = getStore({ name: 'processed-messages', consistency: 'strong' });
     const marker = await store.get(sid, { type: 'json' });
     if (marker && (marker.status === 'done' || marker.status === 'failed')) {
       logDetails(`Skipping ${sid}: already ${marker.status}`);
-      return { statusCode: 200, body: 'Already processed' };
+      return new Response('Already processed', { status: 200 });
     }
     await store.setJSON(sid, { status: 'processing', at: new Date().toISOString() });
   } catch (blobError) {
@@ -78,5 +85,5 @@ exports.handler = async (event) => {
   }
 
   logDetails(`Background processing finished for ${sid}: ${result.flow}`);
-  return { statusCode: 200, body: result.flow };
+  return new Response(result.flow, { status: 200 });
 };


### PR DESCRIPTION
Follow-up to #22 — the production log showed `connectLambda` connected but strong reads still failed: the Lambda-style context never includes `uncachedEdgeURL` (verified in @netlify/blobs source), so strong consistency is structurally impossible in legacy handlers.

## Fix
- **Background function → v2 API** (`transcribe-background.mjs`, default export, Request/Response): gets the full Blobs context automatically → strong-consistency dedup actually works. Logic unchanged.
- **Sync webhook stays Lambda-style** (serverless-http requires Lambda events): its best-effort dedup read drops to eventual consistency (works with connectLambda). The background gate is authoritative for anything that slips through.

## Verified
- 16/16 unit checks (harness updated for the v2 Request/Response signature)
- `netlify functions:serve`: runtime loads the `.mjs` v2 function, queues as background (202), executes token check
- Sync flows regression-tested

After deploy: send a voice note and confirm the log shows **no** "Blobs unavailable" warning — that's the end-to-end confirmation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)