### PR TITLE
Add test suite + CI, operator failure alerts, and hygiene fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,18 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - run: npm test

--- a/README.md
+++ b/README.md
@@ -47,8 +47,17 @@ The app runs in two modes from the same codebase:
 Netlify-only environment variables (set in the Netlify UI, in addition
 to the ones below): `INTERNAL_API_SECRET` (random 32+ chars; auth
 between the two functions) and `TWILIO_WEBHOOK_URL` (the exact URL
-configured in Twilio, used for signature validation). Set
-`TWILIO_SIGNATURE_VALIDATION=off` only for local development.
+configured in Twilio, used for signature validation). Optional:
+`ADMIN_PHONE` (e.g. `whatsapp:+44...`) — when set, the operator gets a
+WhatsApp alert on transcription failures, debounced to one per hour.
+Set `TWILIO_SIGNATURE_VALIDATION=off` only for local development.
+
+## Tests
+
+`npm test` runs the offline test suite (Node's built-in test runner, no
+extra dependencies): localization invariants, Express flows in test
+mode, and the Netlify function handlers (signature validation, dispatch
+handshake, background auth). CI runs it on every PR via GitHub Actions.
 
 ## Requirements
 

--- a/netlify/functions/transcribe-background.mjs
+++ b/netlify/functions/transcribe-background.mjs
@@ -24,6 +24,35 @@ import { TwilioClientWrapper } from '../../src/services/twilio-service.js';
 import { processVoiceNote } from '../../src/core/voice-note-pipeline.js';
 import { logDetails } from '../../src/utils/logging-utils.js';
 
+const ALERT_MARKER_KEY = '_admin-alert-last';
+const ALERT_MUTE_MS = 60 * 60 * 1000; // one alert per hour
+
+/**
+ * Send a WhatsApp alert to the operator (ADMIN_PHONE), debounced via the
+ * Blobs store. Best-effort on every level: if Blobs is down we alert
+ * anyway (visibility over silence), and a failed send is only logged.
+ */
+async function sendAdminAlert(store, twilioClient, result, params) {
+  try {
+    if (store) {
+      const last = await store.get(ALERT_MARKER_KEY, { type: 'json' });
+      if (last && Date.now() - new Date(last.at).getTime() < ALERT_MUTE_MS) {
+        logDetails('Admin alert suppressed (within mute window)');
+        return;
+      }
+      await store.setJSON(ALERT_MARKER_KEY, { at: new Date().toISOString() });
+    }
+    await twilioClient.sendMessage({
+      body: `⚠️ Josephine: transcription failed for ${params.From || 'unknown'} (${params.MessageSid}): ${result.error || 'unknown error'}. Alerts muted for 1h.`,
+      from: process.env.TWILIO_PHONE_NUMBER,
+      to: process.env.ADMIN_PHONE
+    });
+    logDetails('Admin alert sent');
+  } catch (alertError) {
+    logDetails('Failed to send admin alert:', alertError.message);
+  }
+}
+
 export default async (req) => {
   // Only our own sync function may invoke this endpoint.
   const token = req.headers.get('x-internal-token') || '';
@@ -65,13 +94,22 @@ export default async (req) => {
 
   const result = await processVoiceNote(context);
 
+  // Alert the operator on processing errors (expired API key, OpenAI
+  // outage, etc. — the user gets a localized error message, but without
+  // this the operator would never know). Debounced to one alert per hour
+  // via the Blobs store so an outage doesn't spam.
+  if (result.flow === 'processing_error' && process.env.ADMIN_PHONE) {
+    await sendAdminAlert(store, context.twilioClient, result, params);
+  }
+
   // Terminal states: 'done' (user got transcription or violation notice),
-  // 'failed' (user got the localized error message — do not re-spend).
-  // 'retrying': the pipeline succeeded but the Twilio send failed, so the
-  // user got NOTHING — throw to trigger Netlify's automatic retry.
+  // 'failed'/'file_too_big' (user got the localized message — do not
+  // re-spend). 'retrying': the pipeline succeeded but the Twilio send
+  // failed, so the user got NOTHING — throw to trigger Netlify's
+  // automatic retry.
   const status = result.flow === 'twilio_error'
     ? 'retrying'
-    : (result.flow === 'processing_error' ? 'failed' : 'done');
+    : (result.flow === 'processing_error' || result.flow === 'file_too_big' ? 'failed' : 'done');
 
   if (store) {
     try {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "start": "node index.js",
     "dev": "nodemon index.js",
-    "test": "echo \"No tests configured\""
+    "test": "node --test test/localization.test.js test/express-flows.test.js test/netlify-functions.test.js"
   },
   "engines": {
     "node": ">=18"

--- a/src/controllers/transcription.js
+++ b/src/controllers/transcription.js
@@ -100,6 +100,21 @@ async function handleVoiceNote(req, res) {
         message: result.message
       });
 
+    case 'file_too_big':
+      if (result.twilioAvailable) {
+        if (req.isTestMode) {
+          return formatTestResponse(res, {
+            flow: 'file_too_big',
+            message: result.message,
+            testResults: twilioClient.getTestResults()
+          });
+        }
+        return sendXML();
+      }
+      return formatErrorResponse(res, 413, result.message, {
+        flow: 'file_too_big'
+      });
+
     case 'twilio_error':
       return formatErrorResponse(res, 500, 'Failed to send transcription', {
         flow: 'twilio_error',

--- a/src/core/voice-note-pipeline.js
+++ b/src/core/voice-note-pipeline.js
@@ -47,6 +47,24 @@ async function processVoiceNote(context) {
     // Download audio file
     const { data: audioData } = await downloadAudio(mediaUrl, authHeaders, context);
 
+    // Guard against files too large to transcribe (OpenAI caps uploads at
+    // 25MB; leave headroom). WhatsApp media tops out at 16MB so this is a
+    // belt-and-braces check, mostly for non-WhatsApp callers.
+    const MAX_AUDIO_BYTES = 15 * 1024 * 1024;
+    if (audioData && audioData.length > MAX_AUDIO_BYTES) {
+      logDetails('Audio file too large', { size: audioData.length, limit: MAX_AUDIO_BYTES });
+      const fileTooBigMessage = await getLocalizedMessage('fileTooBig', userLang);
+      if (twilioClient.isAvailable()) {
+        await twilioClient.sendMessage({
+          body: fileTooBigMessage,
+          from: toPhone,
+          to: userPhone
+        });
+        return { flow: 'file_too_big', twilioAvailable: true, message: fileTooBigMessage };
+      }
+      return { flow: 'file_too_big', twilioAvailable: false, statusCode: 413, message: fileTooBigMessage };
+    }
+
     // Prepare form data for Whisper API
     const formData = prepareFormData(audioData, mediaContentType);
 
@@ -75,7 +93,7 @@ async function processVoiceNote(context) {
 
     // Check for prohibited content
     const [moderationResult, summary] = await Promise.all([
-      checkContentModeration(transcription, process.env.OPENAI_API_KEY),
+      checkContentModeration(transcription, process.env.OPENAI_API_KEY, context),
       summaryPromise
     ]);
     if (moderationResult.flagged) {

--- a/src/helpers/languages.json
+++ b/src/helpers/languages.json
@@ -10,11 +10,7 @@
     "processingTimeout": "This voice note is taking too long to process. Please try a shorter message or try again later.",
     "rateLimited": "Our service is experiencing high demand. Please try again in a few minutes.",
     "apiError": "Sorry, there's a temporary issue with our service. Our team has been notified.",
-    "contentViolation": "We're unable to process this voice note as it contains content that violates our usage policies. Please review our Terms of Service for more information on acceptable content.",
-    "welcomeIntro": "Hi! I'm Josephine, your friendly transcription assistant 👋. I turn voice notes into text so you can read them at your convenience.",
-    "termsIntro": "By sending audio, you confirm you've read and agreed to my Terms & Conditions https://tinyurl.com/josephine-Terms. Forward a voice note, and I'll do the rest!",
-    "voiceNoteIntro": "Hey there! I see you sent me a voice note 👋. Before I transcribe, I want to make sure you've checked my Terms & Conditions.",
-    "voiceNoteTerms": "By continuing to send audio, you're confirming you've read and agreed to my Terms & Conditions: https://tinyurl.com/josephine-Terms. Please forward your voice note again, and I'll transcribe it right away!"
+    "contentViolation": "We're unable to process this voice note as it contains content that violates our usage policies. Please review our Terms of Service for more information on acceptable content."
   },
   "de": {
     "welcome": "Hallo! Ich bin Josephine, dein Transkriptionsassistent für Sprachnotizen. Schicke mir eine Sprachnotiz und ich transkribiere sie für dich!",
@@ -27,11 +23,7 @@
     "processingTimeout": "Diese Sprachnotiz dauert zu lange zur Verarbeitung. Bitte versuche es mit einer kürzeren Nachricht oder später erneut.",
     "rateLimited": "Unser Service ist derzeit stark ausgelastet. Bitte versuche es in ein paar Minuten erneut.",
     "apiError": "Entschuldigung, es gibt ein temporäres Problem mit unserem Service. Unser Team wurde benachrichtigt.",
-    "contentViolation": "Wir können diese Sprachnotiz nicht verarbeiten, da sie Inhalte enthält, die gegen unsere Nutzungsrichtlinien verstoßen. Bitte lesen Sie unsere Nutzungsbedingungen für weitere Informationen zu akzeptablen Inhalten.",
-    "welcomeIntro": "Hallo! Ich bin Josephine, dein freundlicher Transkriptionsassistent 👋. Ich verwandle Sprachnotizen in Text, damit du sie bequem lesen kannst.",
-    "termsIntro": "Durch das Senden von Audiodateien bestätigst du, dass du meine Nutzungsbedingungen gelesen hast und ihnen zustimmst: https://tinyurl.com/josephine-Terms. Sende eine Sprachnotiz, und ich erledige den Rest!",
-    "voiceNoteIntro": "Hallo! Ich sehe, du hast mir eine Sprachnotiz geschickt 👋. Bevor ich sie transkribiere, möchte ich sicherstellen, dass du meine Nutzungsbedingungen gelesen hast.",
-    "voiceNoteTerms": "Indem du weiterhin Audiodateien sendest, bestätigst du, dass du meine Nutzungsbedingungen gelesen hast und ihnen zustimmst: https://tinyurl.com/josephine-Terms. Bitte sende deine Sprachnotiz erneut, und ich werde sie sofort transkribieren!"
+    "contentViolation": "Wir können diese Sprachnotiz nicht verarbeiten, da sie Inhalte enthält, die gegen unsere Nutzungsrichtlinien verstoßen. Bitte lesen Sie unsere Nutzungsbedingungen für weitere Informationen zu akzeptablen Inhalten."
   },
   "fr": {
     "welcome": "Bonjour! Je suis Josephine, votre assistante de transcription de messages vocaux. Envoyez-moi un message vocal et je le transcrirai pour vous!",
@@ -44,11 +36,7 @@
     "processingTimeout": "Le traitement de ce message vocal prend trop de temps. Veuillez essayer avec un message plus court ou réessayer plus tard.",
     "rateLimited": "Notre service est fortement sollicité. Veuillez réessayer dans quelques minutes.",
     "apiError": "Désolé, il y a un problème temporaire avec notre service. Notre équipe a été alertée.",
-    "contentViolation": "Nous ne pouvons pas traiter cette note vocale car elle contient du contenu qui viole nos politiques d'utilisation. Veuillez consulter nos Conditions d'utilisation pour plus d'informations sur le contenu acceptable.",
-    "welcomeIntro": "Bonjour! Je suis Josephine, votre assistante de transcription 👋. Je transforme les messages vocaux en texte pour que vous puissiez les lire à votre convenance.",
-    "termsIntro": "En envoyant des fichiers audio, vous confirmez avoir lu et accepté mes Conditions d'Utilisation https://tinyurl.com/josephine-Terms. Envoyez un message vocal, et je m'occupe du reste!",
-    "voiceNoteIntro": "Bonjour! Je vois que vous m'avez envoyé un message vocal 👋. Avant de le transcrire, je veux m'assurer que vous avez consulté mes Conditions d'Utilisation.",
-    "voiceNoteTerms": "En continuant à envoyer des fichiers audio, vous confirmez avoir lu et accepté mes Conditions d'Utilisation: https://tinyurl.com/josephine-Terms. Veuillez renvoyer votre message vocal, et je le transcrirai immédiatement!"
+    "contentViolation": "Nous ne pouvons pas traiter cette note vocale car elle contient du contenu qui viole nos politiques d'utilisation. Veuillez consulter nos Conditions d'utilisation pour plus d'informations sur le contenu acceptable."
   },
   "it": {
     "welcome": "Ciao! Sono Josephine, la tua assistente per la trascrizione di messaggi vocali. Inviami un messaggio vocale e lo trascriverò per te!",
@@ -61,11 +49,7 @@
     "processingTimeout": "Il trattamento di questo messaggio vocale richiede troppo tempo. Prova con un messaggio più breve o riprova più tardi.",
     "rateLimited": "Il nostro servizio è molto richiesto. Riprova tra qualche minuto.",
     "apiError": "Spiacente, c'è un problema temporaneo con il nostro servizio. Il nostro team è stato avvisato.",
-    "contentViolation": "Non possiamo elaborare questa nota vocale in quanto contiene contenuti che violano le nostre politiche di utilizzo. Si prega di consultare i nostri Termini di servizio per ulteriori informazioni sui contenuti accettabili.",
-    "welcomeIntro": "Ciao! Sono Josephine, la tua assistente di trascrizione 👋. Trasformo i messaggi vocali in testo così puoi leggerli comodamente.",
-    "termsIntro": "Inviando audio, confermi di aver letto e accettato i miei Termini e Condizioni https://tinyurl.com/josephine-Terms. Inoltra un messaggio vocale e farò il resto!",
-    "voiceNoteIntro": "Ciao! Vedo che mi hai inviato un messaggio vocale 👋. Prima di trascriverlo, voglio assicurarmi che tu abbia controllato i miei Termini e Condizioni.",
-    "voiceNoteTerms": "Continuando a inviare audio, confermi di aver letto e accettato i miei Termini e Condizioni: https://tinyurl.com/josephine-Terms. Per favore, inoltra nuovamente il tuo messaggio vocale e lo trascriverò subito!"
+    "contentViolation": "Non possiamo elaborare questa nota vocale in quanto contiene contenuti che violano le nostre politiche di utilizzo. Si prega di consultare i nostri Termini di servizio per ulteriori informazioni sui contenuti accettabili."
   },
   "es": {
     "welcome": "¡Hola! Soy Josephine, tu asistente de transcripción de notas de voz. Envíame una nota de voz y te la transcribiré.",
@@ -78,11 +62,7 @@
     "processingTimeout": "El procesamiento de esta nota de voz está tardando demasiado. Por favor, intenta con un mensaje más corto o vuelve a intentarlo más tarde.",
     "rateLimited": "Nuestro servicio está experimentando una alta demanda. Por favor, inténtalo de nuevo en unos minutos.",
     "apiError": "Lo siento, hay un problema temporal con nuestro servicio. Nuestro equipo ha sido notificado.",
-    "contentViolation": "No podemos procesar esta nota de voz ya que contiene contenido que viola nuestras políticas de uso. Por favor, revisa nuestros Términos de Servicio para obtener más información sobre el contenido aceptable.",
-    "welcomeIntro": "¡Hola! Soy Josephine, tu asistente de transcripción amigable 👋. Convierto notas de voz en texto para que puedas leerlas cómodamente.",
-    "termsIntro": "Al enviar audio, confirmas que has leído y aceptado mis Términos y Condiciones https://tinyurl.com/josephine-Terms. ¡Envía una nota de voz y yo me encargaré del resto!",
-    "voiceNoteIntro": "¡Hola! Veo que me has enviado una nota de voz 👋. Antes de transcribirla, quiero asegurarme de que hayas revisado mis Términos y Condiciones.",
-    "voiceNoteTerms": "Al continuar enviando audio, confirmas que has leído y aceptado mis Términos y Condiciones: https://tinyurl.com/josephine-Terms. ¡Por favor, reenvía tu nota de voz y la transcribiré de inmediato!"
+    "contentViolation": "No podemos procesar esta nota de voz ya que contiene contenido que viola nuestras políticas de uso. Por favor, revisa nuestros Términos de Servicio para obtener más información sobre el contenido aceptable."
   },
   "pl": {
     "welcome": "Cześć! Jestem Josephine, twoja asystentka do transkrypcji wiadomości głosowych. Wyślij mi wiadomość głosową, a ja ją przetranskrybuję!",
@@ -95,11 +75,7 @@
     "processingTimeout": "Przetwarzanie tej wiadomości głosowej trwa zbyt długo. Spróbuj krótszej wiadomości lub ponownie później.",
     "rateLimited": "Nasz serwis jest obecnie przeciążony. Spróbuj ponownie za kilka minut.",
     "apiError": "Przepraszam, wystąpił tymczasowy problem z naszym serwisem. Nasz zespół został powiadomiony.",
-    "contentViolation": "Nie możemy przetworzyć tej wiadomości głosowej, ponieważ zawiera treści naruszające nasze zasady użytkowania. Zapoznaj się z naszym Regulaminem, aby uzyskać więcej informacji na temat akceptowalnych treści.",
-    "welcomeIntro": "Cześć! Jestem Josephine, twoja przyjazna asystentka transkrypcji 👋. Zamieniam wiadomości głosowe na tekst, abyś mógł/mogła je wygodnie przeczytać.",
-    "termsIntro": "Wysyłając audio, potwierdzasz, że przeczytałeś/aś i zgadzasz się z moim Regulaminem https://tinyurl.com/josephine-Terms. Prześlij wiadomość głosową, a ja zajmę się resztą!",
-    "voiceNoteIntro": "Cześć! Widzę, że wysłałeś/aś mi wiadomość głosową 👋. Zanim ją transkrybuję, chcę upewnić się, że zapoznałeś/aś się z moim Regulaminem.",
-    "voiceNoteTerms": "Kontynuując wysyłanie audio, potwierdzasz, że przeczytałeś/aś i zgadzasz się z moim Regulaminem: https://tinyurl.com/josephine-Terms. Proszę, prześlij ponownie swoją wiadomość głosową, a ja ją od razu transkrybuję!"
+    "contentViolation": "Nie możemy przetworzyć tej wiadomości głosowej, ponieważ zawiera treści naruszające nasze zasady użytkowania. Zapoznaj się z naszym Regulaminem, aby uzyskać więcej informacji na temat akceptowalnych treści."
   },
   "uk": {
     "welcome": "Привіт! Я Джозефін, ваш асистент з транскрипції голосових повідомлень. Надішліть мені голосове повідомлення, і я його транскрибую для вас!",
@@ -112,11 +88,7 @@
     "processingTimeout": "Обробка цього голосового повідомлення займає занадто багато часу. Будь ласка, спробуйте коротше повідомлення або пізніше.",
     "rateLimited": "Наш сервіс зазнає великого навантаження. Будь ласка, спробуйте через кілька хвилин.",
     "apiError": "Вибачте, сталася тимчасова проблема з нашим сервісом. Наша команда повідомлена.",
-    "contentViolation": "Ми не можемо обробити цю голосову нотатку, оскільки вона містить вміст, який порушує наші правила користування. Будь ласка, перегляньте наші Умови надання послуг для отримання додаткової інформації про прийнятний вміст.",
-    "welcomeIntro": "Привіт! Я Джозефін, ваш дружній асистент з транскрипції 👋. Я перетворюю голосові повідомлення на текст, щоб ви могли зручно їх читати.",
-    "termsIntro": "Надсилаючи аудіо, ви підтверджуєте, що прочитали та погодилися з моїми Умовами використання https://tinyurl.com/josephine-Terms. Надішліть голосове повідомлення, і я зроблю все інше!",
-    "voiceNoteIntro": "Привіт! Я бачу, що ви надіслали мені голосове повідомлення 👋. Перш ніж транскрибувати його, я хочу переконатися, що ви ознайомилися з моїми Умовами використання.",
-    "voiceNoteTerms": "Продовжуючи надсилати аудіо, ви підтверджуєте, що прочитали та погодилися з моїми Умовами використання: https://tinyurl.com/josephine-Terms. Будь ласка, перешліть своє голосове повідомлення знову, і я одразу його транскрибую!"
+    "contentViolation": "Ми не можемо обробити цю голосову нотатку, оскільки вона містить вміст, який порушує наші правила користування. Будь ласка, перегляньте наші Умови надання послуг для отримання додаткової інформації про прийнятний вміст."
   },
   "ro": {
     "welcome": "Bună! Sunt Josephine, asistentul tău de transcriere a notelor vocale. Trimite-mi o notă vocală și o voi transcrie pentru tine!",
@@ -129,11 +101,7 @@
     "processingTimeout": "Procesarea acestei note vocale durează prea mult. Te rugăm să încerci cu un mesaj mai scurt sau mai târziu.",
     "rateLimited": "Serviciul nostru este foarte solicitat. Te rugăm să încerci din nou peste câteva minute.",
     "apiError": "Ne pare rău, există o problemă temporară cu serviciul nostru. Echipa noastră a fost notificată.",
-    "contentViolation": "Nu putem procesa această notă vocală deoarece conține conținut care încalcă politicile noastre de utilizare. Vă rugăm să consultați Termenii noștri de serviciu pentru mai multe informații despre conținutul acceptabil.",
-    "welcomeIntro": "Bună! Sunt Josephine, asistentul tău prietenos de transcriere 👋. Transform notele vocale în text pentru ca tu să le poți citi convenabil.",
-    "termsIntro": "Trimițând audio, confirmi că ai citit și ești de acord cu Termenii și Condițiile mele https://tinyurl.com/josephine-Terms. Trimite o notă vocală și mă voi ocupa de restul!",
-    "voiceNoteIntro": "Bună! Văd că mi-ai trimis o notă vocală 👋. Înainte de a o transcrie, vreau să mă asigur că ai verificat Termenii și Condițiile mele.",
-    "voiceNoteTerms": "Continuând să trimiți audio, confirmi că ai citit și ești de acord cu Termenii și Condițiile mele: https://tinyurl.com/josephine-Terms. Te rog, retrimite nota ta vocală și o voi transcrie imediat!"
+    "contentViolation": "Nu putem procesa această notă vocală deoarece conține conținut care încalcă politicile noastre de utilizare. Vă rugăm să consultați Termenii noștri de serviciu pentru mai multe informații despre conținutul acceptabil."
   },
   "nl": {
     "welcome": "Hallo! Ik ben Josephine, jouw assistent voor het transcriberen van spraakberichten. Stuur me een spraakbericht en ik zal het voor je transcriberen!",
@@ -146,11 +114,7 @@
     "processingTimeout": "Dit spraakbericht duurt te lang om te verwerken. Probeer een korter bericht of probeer het later opnieuw.",
     "rateLimited": "Onze service ervaart momenteel hoge belasting. Probeer het over een paar minuten opnieuw.",
     "apiError": "Sorry, er is een tijdelijk probleem met onze service. Ons team is geïnformeerd.",
-    "contentViolation": "We kunnen dit spraakbericht niet verwerken omdat het inhoud bevat die in strijd is met ons gebruiksbeleid. Raadpleeg onze Servicevoorwaarden voor meer informatie over aanvaardbare inhoud.",
-    "welcomeIntro": "Hallo! Ik ben Josephine, je vriendelijke transcriptie-assistent 👋. Ik zet spraakberichten om in tekst zodat je ze gemakkelijk kunt lezen.",
-    "termsIntro": "Door audio te versturen, bevestig je dat je mijn Algemene Voorwaarden hebt gelezen en ermee akkoord gaat https://tinyurl.com/josephine-Terms. Stuur een spraakbericht, en ik doe de rest!",
-    "voiceNoteIntro": "Hallo! Ik zie dat je me een spraakbericht hebt gestuurd 👋. Voordat ik het transcribeer, wil ik zeker weten dat je mijn Algemene Voorwaarden hebt bekeken.",
-    "voiceNoteTerms": "Door audio te blijven versturen, bevestig je dat je mijn Algemene Voorwaarden hebt gelezen en ermee akkoord gaat: https://tinyurl.com/josephine-Terms. Stuur je spraakbericht opnieuw, en ik zal het meteen transcriberen!"
+    "contentViolation": "We kunnen dit spraakbericht niet verwerken omdat het inhoud bevat die in strijd is met ons gebruiksbeleid. Raadpleeg onze Servicevoorwaarden voor meer informatie over aanvaardbare inhoud."
   },
   "sh": {
     "welcome": "Pozdrav! Ja sam Josephine, tvoj asistent za transkripciju glasovnih poruka. Pošalji mi glasovnu poruku i ja ću je transkribovati za tebe!",
@@ -163,11 +127,7 @@
     "processingTimeout": "Obrada ove glasovne poruke traje predugo. Pokušaj s kraćom porukom ili kasnije.",
     "rateLimited": "Naša usluga je trenutno pod velikim opterećenjem. Pokušaj ponovno za nekoliko minuta.",
     "apiError": "Žao nam je, trenutno postoji privremeni problem s našom uslugom. Naš tim je obaviješten.",
-    "contentViolation": "Ne možemo obraditi ovu glasovnu poruku jer sadrži sadržaj koji krši naše politike korištenja. Molimo pregledajte naše Uslove korištenja za više informacija o prihvatljivom sadržaju.",
-    "welcomeIntro": "Pozdrav! Ja sam Josephine, tvoj prijateljski asistent za transkripciju 👋. Pretvaram glasovne poruke u tekst kako bi ih mogao/la pročitati kad ti odgovara.",
-    "termsIntro": "Slanjem audio zapisa, potvrđuješ da si pročitao/la i da se slažeš s mojim Uslovima korištenja https://tinyurl.com/josephine-Terms. Pošalji glasovnu poruku, a ja ću se pobrinuti za ostalo!",
-    "voiceNoteIntro": "Pozdrav! Vidim da si mi poslao/la glasovnu poruku 👋. Prije nego što je transkribujem, želim biti sigurna da si provjerio/la moje Uslove korištenja.",
-    "voiceNoteTerms": "Nastavljajući slati audio, potvrđuješ da si pročitao/la i da se slažeš s mojim Uslovima korištenja: https://tinyurl.com/josephine-Terms. Molim te, proslijedi svoju glasovnu poruku ponovo, i odmah ću je transkribovati!"
+    "contentViolation": "Ne možemo obraditi ovu glasovnu poruku jer sadrži sadržaj koji krši naše politike korištenja. Molimo pregledajte naše Uslove korištenja za više informacija o prihvatljivom sadržaju."
   },
   "tr": {
     "welcome": "Merhaba! Ben Josephine, sesli not transkripsiyon asistanınızım. Bana bir sesli not gönderin, ben de sizin için transkribe olayım!",
@@ -180,11 +140,7 @@
     "processingTimeout": "Bu sesli notun işlenmesi çok uzun sürüyor. Lütfen daha kısa bir mesaj deneyin veya daha sonra tekrar deneyin.",
     "rateLimited": "Servisimiz şu anda yoğun. Lütfen birkaç dakika sonra tekrar deneyin.",
     "apiError": "Üzgünüz, servisimizde geçici bir sorun var. Ekibimiz bilgilendirildi.",
-    "contentViolation": "Bu sesli notu işleyemiyoruz çünkü kullanım politikalarımızı ihlal eden içerikler içeriyor. Kabul edilebilir içerik hakkında daha fazla bilgi için lütfen Hizmet Şartlarımızı inceleyin.",
-    "welcomeIntro": "Merhaba! Ben Josephine, dost canlısı transkripsiyon asistanınızım 👋. Sesli notları, rahatlıkla okuyabileceğiniz metinlere dönüştürüyorum.",
-    "termsIntro": "Ses göndererek, Hizmet Şartlarımı okuduğunuzu ve kabul ettiğinizi onaylıyorsunuz https://tinyurl.com/josephine-Terms. Bir sesli not gönderin, gerisini ben hallederim!",
-    "voiceNoteIntro": "Merhaba! Bana bir sesli not gönderdiğinizi görüyorum 👋. Transkribe etmeden önce, Hizmet Şartlarımı incelediğinizden emin olmak istiyorum.",
-    "voiceNoteTerms": "Ses göndermeye devam ederek, Hizmet Şartlarımı okuduğunuzu ve kabul ettiğinizi onaylıyorsunuz: https://tinyurl.com/josephine-Terms. Lütfen sesli notunuzu tekrar gönderin, hemen transkribe edeceğim!"
+    "contentViolation": "Bu sesli notu işleyemiyoruz çünkü kullanım politikalarımızı ihlal eden içerikler içeriyor. Kabul edilebilir içerik hakkında daha fazla bilgi için lütfen Hizmet Şartlarımızı inceleyin."
   },
   "bar": {
     "welcome": "Griaß di! I bin da Josephine, dei Transkription-Assistentin fia Sprachnotizen. Schick ma a Sprachnotiz und i schreib's fia di auf!",
@@ -197,11 +153,7 @@
     "processingTimeout": "Des dauert z'lang zum Verarbeitn. Probiers mit a kloaner Notiz oder spöter.",
     "rateLimited": "Unser Service is grad stark b'schäftigt. Versuch's in a paar Minutn wieder.",
     "apiError": "Entschuldigung, es gibt a temporäres Problem mit unserm Service. Unser Team is informiert.",
-    "contentViolation": "Mia kennan de Sprachnotiz net verarbeitn, weil's Inhalt drin is, der gegn unsare Nutzungsrichtlinien verstoßt. Bitte schau da unsare Nutzungsbedingungen an für mehr Infos üba erlaubte Inhalte.",
-    "welcomeIntro": "Griaß di! I bin da Josephine, dei freundliche Transkriptions-Assistentin 👋. I mach aus Sprachnotizen Text, damit du's bequem lesn kannst.",
-    "termsIntro": "Wenns ma Audio schickst, bestätigst, dass'd meine Nutzungsbedingungen glesn hast und damit einverstanden bist https://tinyurl.com/josephine-Terms. Schick a Sprachnotiz, und i mach den Rest!",
-    "voiceNoteIntro": "Servus! I siech, du host ma a Sprachnotiz gschickt 👋. Bevor i's transkribier, mecht i sichergehn, dass'd meine Nutzungsbedingungen checkt host.",
-    "voiceNoteTerms": "Wenn'd weiter Audio schickst, bestätigst, dass'd meine Nutzungsbedingungen glesn hast und damit einverstanden bist: https://tinyurl.com/josephine-Terms. Bitte schick dei Sprachnotiz nomal, und i transkribier's sofort!"
+    "contentViolation": "Mia kennan de Sprachnotiz net verarbeitn, weil's Inhalt drin is, der gegn unsare Nutzungsrichtlinien verstoßt. Bitte schau da unsare Nutzungsbedingungen an für mehr Infos üba erlaubte Inhalte."
   },
   "el": {
     "welcome": "Γεια σου! Είμαι η Josephine, η βοηθός μεταγραφής των φωνητικών μηνυμάτων σου. Στείλε μου ένα φωνητικό μήνυμα και θα το μεταγράψω για σένα!",
@@ -214,11 +166,7 @@
     "processingTimeout": "Η επεξεργασία του φωνητικού αυτού μηνύματος διαρκεί πολύ. Δοκίμασε ένα πιο σύντομο μήνυμα ή αργότερα.",
     "rateLimited": "Η υπηρεσία μας αντιμετωπίζει υψηλό φόρτο. Παρακαλώ δοκίμασε ξανά σε λίγα λεπτά.",
     "apiError": "Συγγνώμη, υπάρχει προσωρινό πρόβλημα με την υπηρεσία μας. Η ομάδα μας έχει ενημερωθεί.",
-    "contentViolation": "Δεν μπορούμε να επεξεργαστούμε αυτό το φωνητικό μήνυμα καθώς περιέχει περιεχόμενο που παραβιάζει τις πολιτικές χρήσης μας. Παρακαλούμε ανατρέξτε στους Όρους Υπηρεσίας μας για περισσότερες πληροφορίες σχετικά με το αποδεκτό περιεχόμενο.",
-    "welcomeIntro": "Γεια σου! Είμαι η Josephine, η φιλική σου βοηθός μεταγραφής 👋. Μετατρέπω τα φωνητικά μηνύματα σε κείμενο ώστε να μπορείς να τα διαβάσεις με την άνεσή σου.",
-    "termsIntro": "Με την αποστολή ήχου, επιβεβαιώνεις ότι έχεις διαβάσει και συμφωνείς με τους Όρους και Προϋποθέσεις μου https://tinyurl.com/josephine-Terms. Στείλε ένα φωνητικό μήνυμα, και εγώ θα αναλάβω τα υπόλοιπα!",
-    "voiceNoteIntro": "Γεια σου! Βλέπω ότι μου έστειλες ένα φωνητικό μήνυμα 👋. Πριν το μεταγράψω, θέλω να βεβαιωθώ ότι έχεις ελέγξει τους Όρους και Προϋποθέσεις μου.",
-    "voiceNoteTerms": "Συνεχίζοντας να στέλνεις ήχο, επιβεβαιώνεις ότι έχεις διαβάσει και συμφωνείς με τους Όρους και Προϋποθέσεις μου: https://tinyurl.com/josephine-Terms. Παρακαλώ προώθησε ξανά το φωνητικό σου μήνυμα, και θα το μεταγράψω αμέσως!"
+    "contentViolation": "Δεν μπορούμε να επεξεργαστούμε αυτό το φωνητικό μήνυμα καθώς περιέχει περιεχόμενο που παραβιάζει τις πολιτικές χρήσης μας. Παρακαλούμε ανατρέξτε στους Όρους Υπηρεσίας μας για περισσότερες πληροφορίες σχετικά με το αποδεκτό περιεχόμενο."
   },
   "hu": {
     "welcome": "Helló! Én vagyok Josephine, a hangüzenet-transzkripciós asszisztensed. Küldj egy hangüzenetet, és leírom neked!",
@@ -231,11 +179,7 @@
     "processingTimeout": "Ez a hangüzenet túl sokáig tart a feldolgozásához. Kérlek, próbálj meg egy rövidebb üzenetet vagy később.",
     "rateLimited": "A szolgáltatásunk jelenleg nagy terhelés alatt áll. Kérlek, próbáld meg néhány perc múlva.",
     "apiError": "Sajnálom, ideiglenes probléma adódott a szolgáltatásunkkal. A csapatunk értesítve lett.",
-    "contentViolation": "Nem tudjuk feldolgozni ezt a hangüzenetet, mert olyan tartalmat tartalmaz, amely sérti a használati szabályzatunkat. Kérjük, tekintsd át a Szolgáltatási feltételeinket a megengedett tartalmakról szóló további információkért.",
-    "welcomeIntro": "Szia! Josephine vagyok, a barátságos transzkripciós asszisztensed 👋. A hangüzeneteket szöveggé alakítom, hogy kényelmesen elolvashasd őket.",
-    "termsIntro": "Hang küldésével megerősíted, hogy elolvastad és elfogadod a Felhasználási feltételeimet https://tinyurl.com/josephine-Terms. Küldj egy hangüzenetet, és a többit elintézem!",
-    "voiceNoteIntro": "Szia! Látom, küldtél egy hangüzenetet 👋. Mielőtt átirnám, meg szeretnék győződni arról, hogy ellenőrizted a Felhasználási feltételeimet.",
-    "voiceNoteTerms": "A hangok további küldésével megerősíted, hogy elolvastad és elfogadod a Felhasználási feltételeimet: https://tinyurl.com/josephine-Terms. Kérlek, küldd el újra a hangüzenetedet, és azonnal átirom!"
+    "contentViolation": "Nem tudjuk feldolgozni ezt a hangüzenetet, mert olyan tartalmat tartalmaz, amely sérti a használati szabályzatunkat. Kérjük, tekintsd át a Szolgáltatási feltételeinket a megengedett tartalmakról szóló további információkért."
   },
   "sv": {
     "welcome": "Hej! Jag är Josephine, din assistent för transkribering av röstmeddelanden. Skicka ett röstmeddelande så transkriberar jag det åt dig!",
@@ -248,11 +192,7 @@
     "processingTimeout": "Det tar för lång tid att behandla detta röstmeddelande. Försök med ett kortare meddelande eller försök igen senare.",
     "rateLimited": "Vår tjänst är mycket belastad. Försök igen om några minuter.",
     "apiError": "Förlåt, det är ett tillfälligt problem med vår tjänst. Vårt team har blivit underrättat.",
-    "contentViolation": "Vi kan inte bearbeta detta röstmeddelande eftersom det innehåller innehåll som bryter mot våra användningsvillkor. Vänligen se våra Användarvillkor för mer information om godtagbart innehåll.",
-    "welcomeIntro": "Hej! Jag är Josephine, din vänliga transkriptionsassistent 👋. Jag omvandlar röstmeddelanden till text så att du bekvämt kan läsa dem.",
-    "termsIntro": "Genom att skicka ljud bekräftar du att du har läst och godkänner mina Användarvillkor https://tinyurl.com/josephine-Terms. Skicka ett röstmeddelande, så sköter jag resten!",
-    "voiceNoteIntro": "Hej! Jag ser att du skickade mig ett röstmeddelande 👋. Innan jag transkriberar det vill jag försäkra mig om att du har läst mina Användarvillkor.",
-    "voiceNoteTerms": "Genom att fortsätta skicka ljud bekräftar du att du har läst och godkänner mina Användarvillkor: https://tinyurl.com/josephine-Terms. Var god skicka ditt röstmeddelande igen, så transkriberar jag det omedelbart!"
+    "contentViolation": "Vi kan inte bearbeta detta röstmeddelande eftersom det innehåller innehåll som bryter mot våra användningsvillkor. Vänligen se våra Användarvillkor för mer information om godtagbart innehåll."
   },
   "pt": {
     "welcome": "Olá! Sou a Josephine, a tua assistente de transcrição de mensagens de voz. Envia-me uma mensagem de voz e eu transcrevo-a para ti!",
@@ -265,11 +205,7 @@
     "processingTimeout": "O processamento desta mensagem de voz está a demorar demasiado. Tenta uma mensagem mais curta ou tenta novamente mais tarde.",
     "rateLimited": "O nosso serviço está com muita procura. Por favor, tenta novamente dentro de alguns minutos.",
     "apiError": "Desculpa, há um problema temporário com o nosso serviço. A nossa equipa foi notificada.",
-    "contentViolation": "Não podemos processar esta mensagem de voz porque contém conteúdo que viola as nossas políticas de utilização. Consulta os nossos Termos de Serviço para mais informações sobre conteúdo aceitável.",
-    "welcomeIntro": "Olá! Sou a Josephine, a tua simpática assistente de transcrição 👋. Transformo mensagens de voz em texto para que as possas ler quando quiseres.",
-    "termsIntro": "Ao enviar áudio, confirmas que leste e aceitas os meus Termos e Condições https://tinyurl.com/josephine-Terms. Encaminha uma mensagem de voz e eu trato do resto!",
-    "voiceNoteIntro": "Olá! Vejo que me enviaste uma mensagem de voz 👋. Antes de a transcrever, quero ter a certeza de que leste os meus Termos e Condições.",
-    "voiceNoteTerms": "Ao continuares a enviar áudio, confirmas que leste e aceitas os meus Termos e Condições: https://tinyurl.com/josephine-Terms. Por favor, reenvia a tua mensagem de voz e transcrevo-a de imediato!"
+    "contentViolation": "Não podemos processar esta mensagem de voz porque contém conteúdo que viola as nossas políticas de utilização. Consulta os nossos Termos de Serviço para mais informações sobre conteúdo aceitável."
   },
   "bg": {
     "welcome": "Здравей! Аз съм Josephine, твоят асистент за транскрипция на гласови съобщения. Изпрати ми гласово съобщение и ще го транскрибирам за теб!",
@@ -282,11 +218,7 @@
     "processingTimeout": "Обработката на това гласово съобщение отнема твърде много време. Моля, опитай с по-кратко съобщение или опитай отново по-късно.",
     "rateLimited": "Услугата ни е под голямо натоварване. Моля, опитай отново след няколко минути.",
     "apiError": "Съжалявам, има временен проблем с нашата услуга. Екипът ни е уведомен.",
-    "contentViolation": "Не можем да обработим това гласово съобщение, тъй като съдържа съдържание, което нарушава нашите правила за ползване. Моля, прегледай нашите Условия за ползване за повече информация относно допустимото съдържание.",
-    "welcomeIntro": "Здравей! Аз съм Josephine, твоят приятелски асистент за транскрипция 👋. Превръщам гласовите съобщения в текст, за да можеш да ги четеш, когато ти е удобно.",
-    "termsIntro": "С изпращането на аудио потвърждаваш, че си прочел/а и приемаш моите Общи условия https://tinyurl.com/josephine-Terms. Препрати гласово съобщение и аз ще свърша останалото!",
-    "voiceNoteIntro": "Здравей! Виждам, че си ми изпратил/а гласово съобщение 👋. Преди да го транскрибирам, искам да се уверя, че си прегледал/а моите Общи условия.",
-    "voiceNoteTerms": "Продължавайки да изпращаш аудио, потвърждаваш, че си прочел/а и приемаш моите Общи условия: https://tinyurl.com/josephine-Terms. Моля, препрати гласовото си съобщение отново и веднага ще го транскрибирам!"
+    "contentViolation": "Не можем да обработим това гласово съобщение, тъй като съдържа съдържание, което нарушава нашите правила за ползване. Моля, прегледай нашите Условия за ползване за повече информация относно допустимото съдържание."
   },
   "cs": {
     "welcome": "Ahoj! Jsem Josephine, tvoje asistentka pro přepis hlasových zpráv. Pošli mi hlasovou zprávu a já ti ji přepíšu!",
@@ -299,11 +231,7 @@
     "processingTimeout": "Zpracování této hlasové zprávy trvá příliš dlouho. Zkus prosím kratší zprávu nebo to zkus později.",
     "rateLimited": "Naše služba je momentálně přetížená. Zkus to prosím za pár minut.",
     "apiError": "Omlouvám se, s naší službou je dočasný problém. Náš tým byl informován.",
-    "contentViolation": "Tuto hlasovou zprávu nemůžeme zpracovat, protože obsahuje obsah porušující naše zásady používání. Další informace o přijatelném obsahu najdeš v našich Podmínkách služby.",
-    "welcomeIntro": "Ahoj! Jsem Josephine, tvoje přátelská asistentka pro přepis 👋. Převádím hlasové zprávy na text, aby sis je mohl/a pohodlně přečíst.",
-    "termsIntro": "Odesláním audia potvrzuješ, že sis přečetl/a mé Obchodní podmínky a souhlasíš s nimi https://tinyurl.com/josephine-Terms. Přepošli hlasovou zprávu a o zbytek se postarám!",
-    "voiceNoteIntro": "Ahoj! Vidím, že jsi mi poslal/a hlasovou zprávu 👋. Než ji přepíšu, chci se ujistit, že sis prohlédl/a mé Obchodní podmínky.",
-    "voiceNoteTerms": "Dalším odesíláním audia potvrzuješ, že sis přečetl/a mé Obchodní podmínky a souhlasíš s nimi: https://tinyurl.com/josephine-Terms. Přepošli prosím svou hlasovou zprávu znovu a hned ji přepíšu!"
+    "contentViolation": "Tuto hlasovou zprávu nemůžeme zpracovat, protože obsahuje obsah porušující naše zásady používání. Další informace o přijatelném obsahu najdeš v našich Podmínkách služby."
   },
   "da": {
     "welcome": "Hej! Jeg er Josephine, din assistent til transskription af talebeskeder. Send mig en talebesked, så transskriberer jeg den for dig!",
@@ -316,11 +244,7 @@
     "processingTimeout": "Behandlingen af denne talebesked tager for lang tid. Prøv en kortere besked eller prøv igen senere.",
     "rateLimited": "Vores tjeneste oplever stor efterspørgsel. Prøv venligst igen om et par minutter.",
     "apiError": "Beklager, der er et midlertidigt problem med vores tjeneste. Vores team er blevet underrettet.",
-    "contentViolation": "Vi kan ikke behandle denne talebesked, da den indeholder indhold, der overtræder vores brugspolitikker. Se venligst vores Servicevilkår for mere information om acceptabelt indhold.",
-    "welcomeIntro": "Hej! Jeg er Josephine, din venlige transskriptionsassistent 👋. Jeg omdanner talebeskeder til tekst, så du kan læse dem, når det passer dig.",
-    "termsIntro": "Ved at sende lyd bekræfter du, at du har læst og accepteret mine Vilkår og Betingelser https://tinyurl.com/josephine-Terms. Videresend en talebesked, så klarer jeg resten!",
-    "voiceNoteIntro": "Hej! Jeg kan se, at du har sendt mig en talebesked 👋. Før jeg transskriberer den, vil jeg sikre mig, at du har læst mine Vilkår og Betingelser.",
-    "voiceNoteTerms": "Ved at fortsætte med at sende lyd bekræfter du, at du har læst og accepteret mine Vilkår og Betingelser: https://tinyurl.com/josephine-Terms. Videresend venligst din talebesked igen, så transskriberer jeg den med det samme!"
+    "contentViolation": "Vi kan ikke behandle denne talebesked, da den indeholder indhold, der overtræder vores brugspolitikker. Se venligst vores Servicevilkår for mere information om acceptabelt indhold."
   },
   "et": {
     "welcome": "Tere! Mina olen Josephine, sinu häälsõnumite transkriptsiooni assistent. Saada mulle häälsõnum ja ma transkribeerin selle sinu jaoks!",
@@ -333,11 +257,7 @@
     "processingTimeout": "Selle häälsõnumi töötlemine võtab liiga kaua aega. Palun proovi lühemat sõnumit või proovi hiljem uuesti.",
     "rateLimited": "Meie teenus on suure koormuse all. Palun proovi mõne minuti pärast uuesti.",
     "apiError": "Vabandust, meie teenusega on ajutine probleem. Meie meeskonda on teavitatud.",
-    "contentViolation": "Me ei saa seda häälsõnumit töödelda, kuna see sisaldab sisu, mis rikub meie kasutuspoliitikat. Palun tutvu meie teenusetingimustega, et saada lisateavet vastuvõetava sisu kohta.",
-    "welcomeIntro": "Tere! Mina olen Josephine, sinu sõbralik transkriptsiooniassistent 👋. Muudan häälsõnumid tekstiks, et saaksid neid mugavalt lugeda.",
-    "termsIntro": "Heli saatmisega kinnitad, et oled lugenud minu tingimusi ja nõustud nendega https://tinyurl.com/josephine-Terms. Edasta häälsõnum ja mina teen ülejäänu!",
-    "voiceNoteIntro": "Tere! Näen, et saatsid mulle häälsõnumi 👋. Enne transkribeerimist tahan veenduda, et oled minu tingimustega tutvunud.",
-    "voiceNoteTerms": "Heli saatmist jätkates kinnitad, et oled lugenud minu tingimusi ja nõustud nendega: https://tinyurl.com/josephine-Terms. Palun edasta oma häälsõnum uuesti ja ma transkribeerin selle kohe!"
+    "contentViolation": "Me ei saa seda häälsõnumit töödelda, kuna see sisaldab sisu, mis rikub meie kasutuspoliitikat. Palun tutvu meie teenusetingimustega, et saada lisateavet vastuvõetava sisu kohta."
   },
   "fi": {
     "welcome": "Hei! Olen Josephine, ääniviestien litterointiavustajasi. Lähetä minulle ääniviesti, niin litteroin sen sinulle!",
@@ -350,11 +270,7 @@
     "processingTimeout": "Tämän ääniviestin käsittely kestää liian kauan. Kokeile lyhyempää viestiä tai yritä myöhemmin uudelleen.",
     "rateLimited": "Palvelumme on juuri nyt ruuhkautunut. Yritä uudelleen muutaman minuutin kuluttua.",
     "apiError": "Anteeksi, palvelussamme on tilapäinen ongelma. Tiimillemme on ilmoitettu.",
-    "contentViolation": "Emme voi käsitellä tätä ääniviestiä, koska se sisältää käyttökäytäntöjemme vastaista sisältöä. Katso käyttöehdoistamme lisätietoja hyväksyttävästä sisällöstä.",
-    "welcomeIntro": "Hei! Olen Josephine, ystävällinen litterointiavustajasi 👋. Muunnan ääniviestit tekstiksi, jotta voit lukea ne silloin kun sinulle sopii.",
-    "termsIntro": "Lähettämällä ääntä vahvistat lukeneesi ja hyväksyneesi käyttöehtoni https://tinyurl.com/josephine-Terms. Välitä ääniviesti, niin minä hoidan loput!",
-    "voiceNoteIntro": "Hei! Näen, että lähetit minulle ääniviestin 👋. Ennen kuin litteroin sen, haluan varmistaa, että olet tutustunut käyttöehtoihini.",
-    "voiceNoteTerms": "Jatkamalla äänen lähettämistä vahvistat lukeneesi ja hyväksyneesi käyttöehtoni: https://tinyurl.com/josephine-Terms. Välitä ääniviestisi uudelleen, niin litteroin sen heti!"
+    "contentViolation": "Emme voi käsitellä tätä ääniviestiä, koska se sisältää käyttökäytäntöjemme vastaista sisältöä. Katso käyttöehdoistamme lisätietoja hyväksyttävästä sisällöstä."
   },
   "lv": {
     "welcome": "Sveiki! Es esmu Josephine, tava balss ziņu transkripcijas asistente. Atsūti man balss ziņu, un es to tev transkribēšu!",
@@ -367,11 +283,7 @@
     "processingTimeout": "Šīs balss ziņas apstrāde aizņem pārāk ilgu laiku. Lūdzu, mēģini īsāku ziņu vai mēģini vēlāk vēlreiz.",
     "rateLimited": "Mūsu pakalpojumam pašlaik ir liels pieprasījums. Lūdzu, mēģini vēlreiz pēc dažām minūtēm.",
     "apiError": "Atvainojos, ar mūsu pakalpojumu ir īslaicīga problēma. Mūsu komanda ir informēta.",
-    "contentViolation": "Mēs nevaram apstrādāt šo balss ziņu, jo tā satur saturu, kas pārkāpj mūsu lietošanas noteikumus. Lūdzu, iepazīsties ar mūsu Pakalpojuma noteikumiem, lai uzzinātu vairāk par pieņemamu saturu.",
-    "welcomeIntro": "Sveiki! Es esmu Josephine, tava draudzīgā transkripcijas asistente 👋. Es pārvēršu balss ziņas tekstā, lai tu tās varētu ērti izlasīt.",
-    "termsIntro": "Nosūtot audio, tu apstiprini, ka esi izlasījis/usi un piekrīti maniem Noteikumiem un nosacījumiem https://tinyurl.com/josephine-Terms. Pārsūti balss ziņu, un es parūpēšos par pārējo!",
-    "voiceNoteIntro": "Sveiki! Redzu, ka atsūtīji man balss ziņu 👋. Pirms transkribēšanas vēlos pārliecināties, ka esi iepazinies/usies ar maniem Noteikumiem un nosacījumiem.",
-    "voiceNoteTerms": "Turpinot sūtīt audio, tu apstiprini, ka esi izlasījis/usi un piekrīti maniem Noteikumiem un nosacījumiem: https://tinyurl.com/josephine-Terms. Lūdzu, pārsūti savu balss ziņu vēlreiz, un es to uzreiz transkribēšu!"
+    "contentViolation": "Mēs nevaram apstrādāt šo balss ziņu, jo tā satur saturu, kas pārkāpj mūsu lietošanas noteikumus. Lūdzu, iepazīsties ar mūsu Pakalpojuma noteikumiem, lai uzzinātu vairāk par pieņemamu saturu."
   },
   "lt": {
     "welcome": "Labas! Aš esu Josephine, tavo balso žinučių transkripcijos asistentė. Atsiųsk man balso žinutę ir aš ją tau transkribuosiu!",
@@ -384,11 +296,7 @@
     "processingTimeout": "Šios balso žinutės apdorojimas užtrunka per ilgai. Pabandyk trumpesnę žinutę arba pabandyk vėliau.",
     "rateLimited": "Mūsų paslauga šiuo metu labai apkrauta. Pabandyk dar kartą po kelių minučių.",
     "apiError": "Atsiprašau, su mūsų paslauga kilo laikina problema. Mūsų komanda informuota.",
-    "contentViolation": "Negalime apdoroti šios balso žinutės, nes joje yra turinio, pažeidžiančio mūsų naudojimo taisykles. Daugiau informacijos apie priimtiną turinį rasi mūsų Paslaugų teikimo sąlygose.",
-    "welcomeIntro": "Labas! Aš esu Josephine, tavo draugiška transkripcijos asistentė 👋. Paverčiu balso žinutes tekstu, kad galėtum jas patogiai perskaityti.",
-    "termsIntro": "Siųsdamas/a garso įrašą patvirtini, kad perskaitei ir sutinki su mano Taisyklėmis ir sąlygomis https://tinyurl.com/josephine-Terms. Persiųsk balso žinutę, o aš pasirūpinsiu visa kita!",
-    "voiceNoteIntro": "Labas! Matau, kad atsiuntei man balso žinutę 👋. Prieš transkribuodama noriu įsitikinti, kad susipažinai su mano Taisyklėmis ir sąlygomis.",
-    "voiceNoteTerms": "Toliau siųsdamas/a garso įrašus patvirtini, kad perskaitei ir sutinki su mano Taisyklėmis ir sąlygomis: https://tinyurl.com/josephine-Terms. Persiųsk savo balso žinutę dar kartą ir iškart ją transkribuosiu!"
+    "contentViolation": "Negalime apdoroti šios balso žinutės, nes joje yra turinio, pažeidžiančio mūsų naudojimo taisykles. Daugiau informacijos apie priimtiną turinį rasi mūsų Paslaugų teikimo sąlygose."
   },
   "mt": {
     "welcome": "Bongu! Jien Josephine, l-assistenta tiegħek għat-traskrizzjoni tal-messaġġi bil-vuċi. Ibgħatli messaġġ bil-vuċi u nittraskrivih għalik!",
@@ -401,11 +309,7 @@
     "processingTimeout": "L-ipproċessar ta' dan il-messaġġ bil-vuċi qed jieħu ħin twil wisq. Jekk jogħġbok ipprova messaġġ iqsar jew erġa' pprova aktar tard.",
     "rateLimited": "Is-servizz tagħna għandu domanda għolja bħalissa. Jekk jogħġbok erġa' pprova fi ftit minuti.",
     "apiError": "Jiddispjaċini, hemm problema temporanja bis-servizz tagħna. It-tim tagħna ġie nnotifikat.",
-    "contentViolation": "Ma nistgħux nipproċessaw dan il-messaġġ bil-vuċi għax fih kontenut li jikser il-politiki tal-użu tagħna. Jekk jogħġbok ara t-Termini tas-Servizz tagħna għal aktar informazzjoni dwar kontenut aċċettabbli.",
-    "welcomeIntro": "Bongu! Jien Josephine, l-assistenta ħabiba tiegħek għat-traskrizzjoni 👋. Nibdel il-messaġġi bil-vuċi f'test biex tkun tista' taqrahom meta jaqbillek.",
-    "termsIntro": "Meta tibgħat l-awdjo, tikkonferma li qrajt u taqbel mat-Termini u l-Kundizzjonijiet tiegħi https://tinyurl.com/josephine-Terms. Ibgħat messaġġ bil-vuċi u jien nagħmel il-bqija!",
-    "voiceNoteIntro": "Bongu! Qed nara li bgħattli messaġġ bil-vuċi 👋. Qabel ma nittraskrivih, irrid inkun ċerta li rajt it-Termini u l-Kundizzjonijiet tiegħi.",
-    "voiceNoteTerms": "Jekk tkompli tibgħat l-awdjo, tikkonferma li qrajt u taqbel mat-Termini u l-Kundizzjonijiet tiegħi: https://tinyurl.com/josephine-Terms. Jekk jogħġbok erġa' ibgħat il-messaġġ bil-vuċi tiegħek u nittraskrivih minnufih!"
+    "contentViolation": "Ma nistgħux nipproċessaw dan il-messaġġ bil-vuċi għax fih kontenut li jikser il-politiki tal-użu tagħna. Jekk jogħġbok ara t-Termini tas-Servizz tagħna għal aktar informazzjoni dwar kontenut aċċettabbli."
   },
   "sk": {
     "welcome": "Ahoj! Som Josephine, tvoja asistentka na prepis hlasových správ. Pošli mi hlasovú správu a ja ti ju prepíšem!",
@@ -418,11 +322,7 @@
     "processingTimeout": "Spracovanie tejto hlasovej správy trvá príliš dlho. Skús prosím kratšiu správu alebo to skús neskôr.",
     "rateLimited": "Naša služba je momentálne preťažená. Skús to prosím o pár minút.",
     "apiError": "Prepáč, s našou službou je dočasný problém. Náš tím bol informovaný.",
-    "contentViolation": "Túto hlasovú správu nemôžeme spracovať, pretože obsahuje obsah porušujúci naše zásady používania. Viac informácií o prijateľnom obsahu nájdeš v našich Podmienkach služby.",
-    "welcomeIntro": "Ahoj! Som Josephine, tvoja priateľská asistentka na prepis 👋. Premieňam hlasové správy na text, aby si si ich mohol/mohla pohodlne prečítať.",
-    "termsIntro": "Odoslaním audia potvrdzuješ, že si si prečítal/a moje Obchodné podmienky a súhlasíš s nimi https://tinyurl.com/josephine-Terms. Prepošli hlasovú správu a o zvyšok sa postarám!",
-    "voiceNoteIntro": "Ahoj! Vidím, že si mi poslal/a hlasovú správu 👋. Predtým, ako ju prepíšem, chcem sa uistiť, že si si pozrel/a moje Obchodné podmienky.",
-    "voiceNoteTerms": "Ďalším odosielaním audia potvrdzuješ, že si si prečítal/a moje Obchodné podmienky a súhlasíš s nimi: https://tinyurl.com/josephine-Terms. Prepošli prosím svoju hlasovú správu znova a hneď ju prepíšem!"
+    "contentViolation": "Túto hlasovú správu nemôžeme spracovať, pretože obsahuje obsah porušujúci naše zásady používania. Viac informácií o prijateľnom obsahu nájdeš v našich Podmienkach služby."
   },
   "sl": {
     "welcome": "Živjo! Sem Josephine, tvoja asistentka za prepis glasovnih sporočil. Pošlji mi glasovno sporočilo in ti ga bom prepisala!",
@@ -435,11 +335,7 @@
     "processingTimeout": "Obdelava tega glasovnega sporočila traja predolgo. Poskusi s krajšim sporočilom ali poskusi znova pozneje.",
     "rateLimited": "Naša storitev je trenutno zelo obremenjena. Poskusi znova čez nekaj minut.",
     "apiError": "Oprosti, z našo storitvijo je začasna težava. Naša ekipa je bila obveščena.",
-    "contentViolation": "Tega glasovnega sporočila ne moremo obdelati, ker vsebuje vsebino, ki krši naše pravilnike o uporabi. Za več informacij o sprejemljivi vsebini si oglej naše Pogoje storitve.",
-    "welcomeIntro": "Živjo! Sem Josephine, tvoja prijazna asistentka za prepis 👋. Glasovna sporočila spreminjam v besedilo, da jih lahko prebereš, kadar ti ustreza.",
-    "termsIntro": "S pošiljanjem zvoka potrjuješ, da si prebral/a moje Pogoje poslovanja in se z njimi strinjaš https://tinyurl.com/josephine-Terms. Posreduj glasovno sporočilo, jaz pa poskrbim za ostalo!",
-    "voiceNoteIntro": "Živjo! Vidim, da si mi poslal/a glasovno sporočilo 👋. Preden ga prepišem, se želim prepričati, da si preveril/a moje Pogoje poslovanja.",
-    "voiceNoteTerms": "Z nadaljnjim pošiljanjem zvoka potrjuješ, da si prebral/a moje Pogoje poslovanja in se z njimi strinjaš: https://tinyurl.com/josephine-Terms. Prosim, znova posreduj svoje glasovno sporočilo in takoj ga bom prepisala!"
+    "contentViolation": "Tega glasovnega sporočila ne moremo obdelati, ker vsebuje vsebino, ki krši naše pravilnike o uporabi. Za več informacij o sprejemljivi vsebini si oglej naše Pogoje storitve."
   },
   "zh": {
     "welcome": "你好！我是 Josephine，你的语音消息转文字助手。发送一条语音消息给我，我会为你转成文字！",
@@ -452,11 +348,7 @@
     "processingTimeout": "这条语音消息处理时间过长。请尝试发送较短的消息，或稍后再试。",
     "rateLimited": "我们的服务目前需求量很大。请几分钟后再试。",
     "apiError": "抱歉，我们的服务出现了临时问题。我们的团队已收到通知。",
-    "contentViolation": "我们无法处理这条语音消息，因为其中包含违反我们使用政策的内容。请查看我们的服务条款，了解有关可接受内容的更多信息。",
-    "welcomeIntro": "你好！我是 Josephine，你友好的转写助手 👋。我把语音消息变成文字，方便你随时阅读。",
-    "termsIntro": "发送音频即表示你已阅读并同意我的条款与条件 https://tinyurl.com/josephine-Terms。转发一条语音消息，剩下的交给我！",
-    "voiceNoteIntro": "你好！我看到你发来了一条语音消息 👋。在转写之前，我想确认你已经查看了我的条款与条件。",
-    "voiceNoteTerms": "继续发送音频即表示你已阅读并同意我的条款与条件：https://tinyurl.com/josephine-Terms。请再次转发你的语音消息，我会立即为你转写！"
+    "contentViolation": "我们无法处理这条语音消息，因为其中包含违反我们使用政策的内容。请查看我们的服务条款，了解有关可接受内容的更多信息。"
   },
   "hi": {
     "welcome": "नमस्ते! मैं Josephine हूँ, आपकी वॉयस नोट ट्रांसक्रिप्शन सहायक। मुझे एक वॉयस नोट भेजें और मैं उसे आपके लिए लिख दूँगी!",
@@ -469,11 +361,7 @@
     "processingTimeout": "इस वॉयस नोट को प्रोसेस करने में बहुत समय लग रहा है। कृपया छोटा संदेश भेजें या बाद में पुनः प्रयास करें।",
     "rateLimited": "हमारी सेवा पर अभी बहुत अधिक मांग है। कृपया कुछ मिनटों में पुनः प्रयास करें।",
     "apiError": "क्षमा करें, हमारी सेवा में एक अस्थायी समस्या है। हमारी टीम को सूचित कर दिया गया है।",
-    "contentViolation": "हम इस वॉयस नोट को प्रोसेस नहीं कर सकते क्योंकि इसमें ऐसी सामग्री है जो हमारी उपयोग नीतियों का उल्लंघन करती है। स्वीकार्य सामग्री के बारे में अधिक जानकारी के लिए कृपया हमारी सेवा की शर्तें देखें।",
-    "welcomeIntro": "नमस्ते! मैं Josephine हूँ, आपकी मित्रवत ट्रांसक्रिप्शन सहायक 👋। मैं वॉयस नोट्स को टेक्स्ट में बदलती हूँ ताकि आप उन्हें अपनी सुविधा से पढ़ सकें।",
-    "termsIntro": "ऑडियो भेजकर, आप पुष्टि करते हैं कि आपने मेरे नियम और शर्तें पढ़ ली हैं और उनसे सहमत हैं https://tinyurl.com/josephine-Terms। एक वॉयस नोट फॉरवर्ड करें, बाकी मैं संभाल लूँगी!",
-    "voiceNoteIntro": "नमस्ते! मैं देख रही हूँ कि आपने मुझे एक वॉयस नोट भेजा है 👋। ट्रांसक्राइब करने से पहले, मैं सुनिश्चित करना चाहती हूँ कि आपने मेरे नियम और शर्तें देख ली हैं।",
-    "voiceNoteTerms": "ऑडियो भेजना जारी रखकर, आप पुष्टि करते हैं कि आपने मेरे नियम और शर्तें पढ़ ली हैं और उनसे सहमत हैं: https://tinyurl.com/josephine-Terms। कृपया अपना वॉयस नोट फिर से फॉरवर्ड करें, और मैं उसे तुरंत ट्रांसक्राइब कर दूँगी!"
+    "contentViolation": "हम इस वॉयस नोट को प्रोसेस नहीं कर सकते क्योंकि इसमें ऐसी सामग्री है जो हमारी उपयोग नीतियों का उल्लंघन करती है। स्वीकार्य सामग्री के बारे में अधिक जानकारी के लिए कृपया हमारी सेवा की शर्तें देखें।"
   },
   "ja": {
     "welcome": "こんにちは！私はJosephine、ボイスメッセージの文字起こしアシスタントです。ボイスメッセージを送っていただければ、文字に起こします！",
@@ -486,10 +374,6 @@
     "processingTimeout": "このボイスメッセージの処理に時間がかかりすぎています。短いメッセージでお試しいただくか、後ほどもう一度お試しください。",
     "rateLimited": "現在サービスが混み合っています。数分後にもう一度お試しください。",
     "apiError": "申し訳ありません、サービスに一時的な問題が発生しています。チームに通知済みです。",
-    "contentViolation": "このボイスメッセージには利用ポリシーに違反するコンテンツが含まれているため、処理できません。許容されるコンテンツの詳細については、利用規約をご確認ください。",
-    "welcomeIntro": "こんにちは！私はJosephine、あなたのフレンドリーな文字起こしアシスタントです 👋。ボイスメッセージをテキストに変換するので、都合のよいときに読むことができます。",
-    "termsIntro": "音声を送信することで、利用規約 https://tinyurl.com/josephine-Terms を読み、同意したものとみなされます。ボイスメッセージを転送してください。あとは私にお任せください！",
-    "voiceNoteIntro": "こんにちは！ボイスメッセージが届きました 👋。文字起こしの前に、利用規約をご確認いただいたかどうか確認させてください。",
-    "voiceNoteTerms": "音声の送信を続けることで、利用規約 https://tinyurl.com/josephine-Terms を読み、同意したものとみなされます。ボイスメッセージをもう一度転送していただければ、すぐに文字起こしいたします！"
+    "contentViolation": "このボイスメッセージには利用ポリシーに違反するコンテンツが含まれているため、処理できません。許容されるコンテンツの詳細については、利用規約をご確認ください。"
   }
 }

--- a/src/services/moderation-service.js
+++ b/src/services/moderation-service.js
@@ -2,7 +2,14 @@
 const axios = require('axios');
 const { logDetails } = require('../utils/logging-utils');
 
-async function checkContentModeration(text, apiKey) {
+async function checkContentModeration(text, apiKey, req = null) {
+  // Return mock data for test mode (consistent with the other services —
+  // test mode must never make real API calls)
+  if (req && req.isTestMode) {
+    logDetails('[TEST MODE] Simulating content moderation check');
+    return { flagged: false, categories: {}, scores: {}, mockData: true };
+  }
+
   try {
     const response = await axios.post(
       'https://api.openai.com/v1/moderations',

--- a/test/express-flows.test.js
+++ b/test/express-flows.test.js
@@ -1,0 +1,106 @@
+// test/express-flows.test.js
+// End-to-end HTTP tests of the Express app in test mode. Test mode mocks
+// every external API (Twilio, OpenAI transcription, moderation), so these
+// run offline with no keys. This is the same app served by Heroku/local
+// `npm start` and by the Netlify sync function's delegate path.
+const { test, before, after } = require('node:test');
+const assert = require('node:assert');
+const app = require('../src/app');
+
+let server;
+let base;
+
+before(async () => {
+  await new Promise((resolve) => { server = app.listen(0, resolve); });
+  base = `http://127.0.0.1:${server.address().port}`;
+});
+
+after(() => server.close());
+
+async function post(body) {
+  const res = await fetch(`${base}/transcribe`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body)
+  });
+  return { status: res.status, json: await res.json() };
+}
+
+const VOICE = {
+  testMode: 'true',
+  From: 'whatsapp:+39123',
+  To: 'whatsapp:+1',
+  NumMedia: '1',
+  MediaContentType0: 'audio/ogg',
+  MediaUrl0: 'http://example.invalid/a.ogg',
+  MessageSid: 'SM-test'
+};
+
+test('health check', async () => {
+  const res = await fetch(`${base}/`);
+  assert.strictEqual(res.status, 200);
+  assert.match(await res.text(), /Josephine/);
+});
+
+test('welcome message in Italian from phone prefix', async () => {
+  const { status, json } = await post({ testMode: 'true', From: 'whatsapp:+3912345', NumMedia: '0', MessageSid: 'SM-w' });
+  assert.strictEqual(status, 200);
+  assert.strictEqual(json.flow, 'welcome_message');
+  assert.strictEqual(json.language.code, 'it');
+  assert.match(json.message, /Ciao! Sono Josephine/);
+});
+
+test('welcome message served from file for pre-translated languages', async () => {
+  // These come from languages.json — no OPENAI_API_KEY exists in the test
+  // environment, so a correct non-English reply proves no API call happened.
+  const cases = [
+    ['whatsapp:+380671234567', /Привіт/],
+    ['whatsapp:+905321234567', /Merhaba/],
+    ['whatsapp:+351911234567', /Olá! Sou a Josephine/]
+  ];
+  for (const [from, pattern] of cases) {
+    const { status, json } = await post({ testMode: 'true', From: from, NumMedia: '0', MessageSid: 'SM-w2' });
+    assert.strictEqual(status, 200);
+    assert.match(json.message, pattern, `${from} welcome`);
+  }
+});
+
+test('language detection endpoint', async () => {
+  const { status, json } = await post({ testLanguage: 'true', From: '+39123456789' });
+  assert.strictEqual(status, 200);
+  assert.strictEqual(json.detected_language.code, 'it');
+});
+
+test('voice note: successful transcription with summary:null contract', async () => {
+  const { status, json } = await post(VOICE);
+  assert.strictEqual(status, 200);
+  assert.strictEqual(json.flow, 'successful_transcription');
+  assert.ok('summary' in json, 'summary key must be present');
+  assert.strictEqual(json.summary, null, 'short note summary must be null');
+  assert.ok(json.transcription.length > 0);
+  assert.strictEqual(json.testResults.messages.length, 1);
+});
+
+test('voice note: long transcription generates summary', async () => {
+  const { status, json } = await post({ ...VOICE, longTranscription: 'true', MessageSid: 'SM-long' });
+  assert.strictEqual(status, 200);
+  assert.strictEqual(json.flow, 'successful_transcription');
+  assert.ok(json.summary && json.summary.length > 0, 'summary must be generated');
+});
+
+test('non-audio media prompts for a voice note', async () => {
+  const { status, json } = await post({ ...VOICE, MediaContentType0: 'image/jpeg', MessageSid: 'SM-img' });
+  assert.strictEqual(status, 200);
+  assert.strictEqual(json.flow, 'non_audio_media');
+});
+
+test('missing media fields returns 400', async () => {
+  const { status } = await post({ ...VOICE, MediaUrl0: undefined, MediaContentType0: undefined, MessageSid: 'SM-bad' });
+  assert.strictEqual(status, 400);
+});
+
+test('request without MessageSid returns API info', async () => {
+  const { status, json } = await post({});
+  assert.strictEqual(status, 200);
+  assert.ok(json.expected_params, 'should describe expected params');
+});

--- a/test/localization.test.js
+++ b/test/localization.test.js
@@ -1,0 +1,87 @@
+// test/localization.test.js
+// Invariants over languages.json and the phone-prefix map. These catch
+// the two classes of bug found in July 2026: languages mapped from phone
+// prefixes without translations (silent per-message OpenAI fallback
+// cost), and translations present but unreachable from the map.
+const { test } = require('node:test');
+const assert = require('node:assert');
+
+const translations = require('../src/helpers/languages.json');
+const { getUserLanguage, detectCountryCode, exceedsWordLimit } = require('../src/helpers/localization');
+
+test('every language block has exactly the same keys as en', () => {
+  const enKeys = Object.keys(translations.en).sort();
+  for (const [lang, block] of Object.entries(translations)) {
+    assert.deepStrictEqual(
+      Object.keys(block).sort(),
+      enKeys,
+      `language "${lang}" has mismatched keys`
+    );
+  }
+});
+
+test('no message string is empty', () => {
+  for (const [lang, block] of Object.entries(translations)) {
+    for (const [key, value] of Object.entries(block)) {
+      assert.ok(typeof value === 'string' && value.length > 0, `${lang}.${key} is empty`);
+    }
+  }
+});
+
+test('strings with links keep them in every language', () => {
+  for (const [key, enValue] of Object.entries(translations.en)) {
+    for (const url of ['https://revolut.me/magicfranci']) {
+      if (!enValue.includes(url)) continue;
+      for (const lang of Object.keys(translations)) {
+        assert.ok(
+          translations[lang][key].includes(url),
+          `${lang}.${key} lost the link ${url}`
+        );
+      }
+    }
+  }
+});
+
+test('every mapped phone prefix resolves to a language with translations', () => {
+  // Walk the map through its public API by probing known prefixes plus
+  // every language returned for any 1-3 digit prefix.
+  for (let code = 1; code <= 999; code++) {
+    const lang = getUserLanguage(`whatsapp:+${code}5551234567`);
+    assert.ok(
+      translations[lang.code],
+      `prefix +${code} maps to "${lang.code}" which has no translations (would trigger a live OpenAI call per message)`
+    );
+  }
+});
+
+test('specific prefix routing', () => {
+  const cases = [
+    ['whatsapp:+393331234567', 'it'],
+    ['whatsapp:+380671234567', 'uk'],   // was unreachable before 2026-07-11
+    ['whatsapp:+905321234567', 'tr'],   // was unreachable before 2026-07-11
+    ['whatsapp:+351911234567', 'pt'],
+    ['whatsapp:+8613912345678', 'zh'],
+    ['whatsapp:+919812345678', 'hi'],
+    ['whatsapp:+81901234567', 'ja'],
+    ['whatsapp:+447753980466', 'en'],
+    ['+15551234567', 'en'],
+    [null, 'en'],                        // missing number falls back to default
+  ];
+  for (const [phone, expected] of cases) {
+    assert.strictEqual(getUserLanguage(phone).code, expected, `${phone} should map to ${expected}`);
+  }
+});
+
+test('detectCountryCode strips whatsapp: prefix and plus sign', () => {
+  assert.strictEqual(detectCountryCode('whatsapp:+393331234567'), '39');
+  assert.strictEqual(detectCountryCode('+393331234567'), '39');
+  assert.strictEqual(detectCountryCode('393331234567'), '39');
+  assert.strictEqual(detectCountryCode(undefined), 'default');
+});
+
+test('exceedsWordLimit', () => {
+  assert.strictEqual(exceedsWordLimit('one two three', 5), false);
+  assert.strictEqual(exceedsWordLimit('a '.repeat(151).trim(), 150), true);
+  assert.strictEqual(exceedsWordLimit('', 150), false);
+  assert.strictEqual(exceedsWordLimit(null, 150), false);
+});

--- a/test/netlify-functions.test.js
+++ b/test/netlify-functions.test.js
@@ -1,0 +1,160 @@
+// test/netlify-functions.test.js
+// Unit tests for the two Netlify functions: the sync webhook (Lambda-style
+// handler) and the background worker (v2 API). Covers Twilio signature
+// validation, the dispatch handshake, and the background auth + pipeline
+// error classification. Runs offline: Blobs fail-opens by design in local
+// environments, and no real API keys are set.
+const { test, before, after } = require('node:test');
+const assert = require('node:assert');
+const http = require('http');
+const crypto = require('crypto');
+const querystring = require('querystring');
+
+// Environment the functions expect — set before anything is invoked.
+process.env.INTERNAL_API_SECRET = 'test-secret-123';
+process.env.TWILIO_WEBHOOK_URL = 'https://josephine.test/transcribe';
+process.env.AUTH_TOKEN = 'fake-auth-token';
+// Deliberately NOT set: ACCOUNT_SID (so no real Twilio client is ever
+// created), OPENAI_API_KEY, ADMIN_PHONE.
+
+const syncFn = require('../netlify/functions/transcribe.js');
+
+let bgHandler;
+async function invokeBackground(headers, body) {
+  if (!bgHandler) {
+    bgHandler = (await import('../netlify/functions/transcribe-background.mjs')).default;
+  }
+  const req = new Request('https://local.test/.netlify/functions/transcribe-background', {
+    method: 'POST',
+    headers,
+    body
+  });
+  const res = await bgHandler(req);
+  return { status: res.status, body: await res.text() };
+}
+
+function formEvent(params, headers = {}) {
+  return {
+    httpMethod: 'POST',
+    path: '/transcribe',
+    rawUrl: process.env.TWILIO_WEBHOOK_URL,
+    headers: { 'content-type': 'application/x-www-form-urlencoded', ...headers },
+    queryStringParameters: {},
+    body: querystring.stringify(params),
+    isBase64Encoded: false
+  };
+}
+
+// Twilio's documented signing scheme: URL + sorted key/value concatenation,
+// HMAC-SHA1 with the auth token, base64.
+function twilioSignature(params) {
+  const data = process.env.TWILIO_WEBHOOK_URL +
+    Object.keys(params).sort().map((k) => k + params[k]).join('');
+  return crypto.createHmac('sha1', process.env.AUTH_TOKEN).update(Buffer.from(data, 'utf-8')).digest('base64');
+}
+
+const PROD_VOICE = {
+  From: 'whatsapp:+393331234567',
+  To: 'whatsapp:+1415',
+  NumMedia: '1',
+  MediaContentType0: 'audio/ogg',
+  MediaUrl0: 'https://api.twilio.com/media/ME123',
+  MessageSid: 'SM-prod-1'
+};
+
+// Mock background server so dispatch tests never leave the machine.
+let mock;
+let mockStatus = 202;
+const dispatches = [];
+
+before(async () => {
+  mock = http.createServer((req, res) => {
+    let data = '';
+    req.on('data', (c) => { data += c; });
+    req.on('end', () => {
+      dispatches.push({ url: req.url, token: req.headers['x-internal-token'], body: JSON.parse(data) });
+      res.writeHead(mockStatus);
+      res.end();
+    });
+  });
+  await new Promise((resolve) => mock.listen(0, resolve));
+  process.env.URL = `http://127.0.0.1:${mock.address().port}`;
+});
+
+after(() => mock.close());
+
+// ---------- sync webhook ----------
+
+test('test-mode flows delegate to Express', async () => {
+  const r = await syncFn.handler(formEvent({ testMode: 'true', From: '+3912345', NumMedia: '0', MessageSid: 'SM-w' }), {});
+  assert.strictEqual(r.statusCode, 200);
+  const json = JSON.parse(r.body);
+  assert.strictEqual(json.flow, 'welcome_message');
+  assert.strictEqual(json.language.code, 'it');
+});
+
+test('test mode via x-test-mode header', async () => {
+  const r = await syncFn.handler(formEvent({ From: '+3912345', NumMedia: '0', MessageSid: 'SM-h' }, { 'x-test-mode': 'true' }), {});
+  assert.strictEqual(r.statusCode, 200);
+  assert.strictEqual(JSON.parse(r.body).flow, 'welcome_message');
+});
+
+test('production request without signature is rejected 403', async () => {
+  const r = await syncFn.handler(formEvent(PROD_VOICE), {});
+  assert.strictEqual(r.statusCode, 403);
+});
+
+test('production request with wrong signature is rejected 403', async () => {
+  const r = await syncFn.handler(formEvent(PROD_VOICE, { 'x-twilio-signature': 'bogus' }), {});
+  assert.strictEqual(r.statusCode, 403);
+});
+
+test('valid signature dispatches to background and acks with empty TwiML', async () => {
+  dispatches.length = 0;
+  const r = await syncFn.handler(formEvent(PROD_VOICE, { 'x-twilio-signature': twilioSignature(PROD_VOICE) }), {});
+  assert.strictEqual(r.statusCode, 200);
+  assert.strictEqual(r.headers['Content-Type'], 'text/xml');
+  assert.strictEqual(r.body, '<Response></Response>');
+  assert.strictEqual(dispatches.length, 1);
+  assert.strictEqual(dispatches[0].url, '/.netlify/functions/transcribe-background');
+  assert.strictEqual(dispatches[0].token, 'test-secret-123');
+  assert.strictEqual(dispatches[0].body.MessageSid, PROD_VOICE.MessageSid);
+  assert.strictEqual(dispatches[0].body.MediaUrl0, PROD_VOICE.MediaUrl0);
+});
+
+test('failed dispatch returns 500 so Twilio retries', async () => {
+  mockStatus = 500;
+  const params = { ...PROD_VOICE, MessageSid: 'SM-prod-2' };
+  const r = await syncFn.handler(formEvent(params, { 'x-twilio-signature': twilioSignature(params) }), {});
+  assert.strictEqual(r.statusCode, 500);
+  mockStatus = 202;
+});
+
+// ---------- background worker (v2) ----------
+
+test('background rejects missing internal token', async () => {
+  const r = await invokeBackground({}, JSON.stringify(PROD_VOICE));
+  assert.strictEqual(r.status, 401);
+});
+
+test('background rejects wrong internal token', async () => {
+  const r = await invokeBackground({ 'x-internal-token': 'wrong' }, JSON.stringify(PROD_VOICE));
+  assert.strictEqual(r.status, 401);
+});
+
+test('background rejects malformed payloads', async () => {
+  let r = await invokeBackground({ 'x-internal-token': 'test-secret-123' }, 'not json');
+  assert.strictEqual(r.status, 400);
+  r = await invokeBackground({ 'x-internal-token': 'test-secret-123' }, JSON.stringify({ foo: 1 }));
+  assert.strictEqual(r.status, 400);
+});
+
+test('background runs the pipeline and classifies download failure', async () => {
+  // Unreachable media host, no Twilio client, no OpenAI key: the pipeline
+  // must fail on download and classify it as processing_error (which the
+  // worker records as terminal — no retry, user already got the message).
+  const badMedia = { ...PROD_VOICE, MessageSid: 'SM-bg-1', MediaUrl0: 'http://nonexistent.invalid/a.ogg' };
+  const r = await invokeBackground({ 'x-internal-token': 'test-secret-123' }, JSON.stringify(badMedia));
+  assert.strictEqual(r.status, 200);
+  assert.strictEqual(r.body, 'processing_error');
+});


### PR DESCRIPTION
Items 1, 3, 4 from the repo improvement review.

## 1. Tests + CI
- **26 offline tests** using Node's built-in runner (zero new deps): localization invariants (key parity across 29 languages, every prefix 1–999 resolves to real translations — catches both bug classes found this week), Express flows (incl. the `summary:null` contract), and Netlify function units (signature HMAC accept/reject, dispatch handshake vs a mock server, background auth, error classification)
- **GitHub Actions** workflow runs `npm test` on every PR and main push

## 3. Operator alerting
On `processing_error` the background worker WhatsApps `ADMIN_PHONE` (new optional env var), debounced to 1/hour via Blobs. Previously an expired OpenAI key or Twilio balance would be visible only to end users.

## 4. Hygiene
- Moderation service gets the test-mode mock branch every other service had — no more real API call in test mode (also makes tests hermetic)
- 15MB audio size guard wiring the dead `fileTooBig` key (new `file_too_big` flow, 413, terminal marker)
- Removed 4 dead localization keys × 29 languages (116 strings) — remnants of the removed first-time-user flow
- README updated

## Verified
26/26 locally; CI runs on this very PR as its first live test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)