### PR TITLE
Guarantee ordered delivery of multi-part transcriptions

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "start": "node index.js",
     "dev": "nodemon index.js",
-    "test": "node --test test/localization.test.js test/express-flows.test.js test/netlify-functions.test.js test/cost-estimate.test.js"
+    "test": "node --test test/localization.test.js test/express-flows.test.js test/netlify-functions.test.js test/cost-estimate.test.js test/messaging-service.test.js"
   },
   "engines": {
     "node": ">=18"

--- a/src/services/messaging-service.js
+++ b/src/services/messaging-service.js
@@ -11,23 +11,55 @@ function splitLongMessage(message, maxLength = 1500) {
   return parts;
 }
 
+// Twilio statuses that mean a message has left the outbound queue and been
+// handed to Meta. Once a part reaches one of these, the next part can be
+// queued without risk of overtaking it. 'queued'/'accepted'/'scheduled'
+// are the states we must wait *out* of.
+const DISPATCHED_STATUSES = new Set([
+  'sending', 'sent', 'delivered', 'read', 'receiving', 'received',
+  'undelivered', 'failed'
+]);
+
+/**
+ * Wait until a message has left Twilio's outbound queue (status advances
+ * past 'queued'/'accepted'), so the next part cannot overtake it on the
+ * way to Meta. Fail-open: if the status can't be read or never advances
+ * within the budget, we return anyway rather than block the send — worst
+ * case is the pre-existing rare-reorder behaviour, never a dropped part.
+ */
+async function waitUntilDispatched(twilioWrapper, sid, { attempts = 8, intervalMs = 500 } = {}) {
+  for (let i = 0; i < attempts; i++) {
+    const status = await twilioWrapper.getMessageStatus(sid);
+    if (status === null || DISPATCHED_STATUSES.has(status)) {
+      return status;
+    }
+    await new Promise(resolve => setTimeout(resolve, intervalMs));
+  }
+  return null;
+}
+
 async function sendMessages(twilioWrapper, messageParts, toPhone, fromPhone) {
   try {
     logDetails(`Message will be split into ${messageParts.length} parts`);
-    
+
     for (const [index, part] of messageParts.entries()) {
-      await twilioWrapper.sendMessage({
+      const result = await twilioWrapper.sendMessage({
         body: part,
         from: fromPhone,
         to: toPhone
       });
-      
-      // Add a small delay between messages to maintain order (in non-test mode)
+
+      // Between parts, wait for this one to actually leave Twilio's queue
+      // before submitting the next. Awaiting the REST POST only confirms
+      // Twilio *queued* the message; two messages queued back-to-back can
+      // still reach Meta out of order. Polling to a dispatched status is
+      // what keeps WhatsApp showing the parts in order. (Skipped in test
+      // mode — no real sends, nothing to poll.)
       if (!twilioWrapper.testMode && messageParts.length > 1 && index < messageParts.length - 1) {
-        await new Promise(resolve => setTimeout(resolve, 500));
+        await waitUntilDispatched(twilioWrapper, result && result.sid);
       }
     }
-    
+
     logDetails(`Messages sent successfully in ${messageParts.length} parts`);
     return true;
   } catch (error) {
@@ -38,5 +70,6 @@ async function sendMessages(twilioWrapper, messageParts, toPhone, fromPhone) {
 
 module.exports = {
   splitLongMessage,
-  sendMessages
+  sendMessages,
+  waitUntilDispatched
 };

--- a/src/services/twilio-service.js
+++ b/src/services/twilio-service.js
@@ -3,7 +3,7 @@
 // the twilio SDK was removed because its dynamic requires break Netlify's
 // v2 function bundling (production MODULE_NOT_FOUND, 2026-07-11), and the
 // SDK's only runtime use here was messages.create.
-const { postJson } = require('../utils/http-client');
+const { postJson, getJson } = require('../utils/http-client');
 const { logDetails } = require('../utils/logging-utils');
 
 // Twilio client wrapper
@@ -61,6 +61,33 @@ class TwilioClientWrapper {
       );
     } else {
       throw new Error('Twilio client not available');
+    }
+  }
+
+  // Fetch the current delivery status of a previously-sent message.
+  // Used to sequence multi-part sends: we only queue the next part once
+  // the previous one has left Twilio's outbound queue (see sendMessages),
+  // which is what actually guarantees WhatsApp shows them in order.
+  // Returns the Twilio status string (e.g. 'queued', 'sent', 'delivered')
+  // or null if it can't be read (fail-open — never block a send on this).
+  async getMessageStatus(sid) {
+    if (this.testMode || !this.hasCredentials || !sid) {
+      return null;
+    }
+    try {
+      const accountSid = process.env.ACCOUNT_SID;
+      const auth = Buffer.from(`${accountSid}:${process.env.AUTH_TOKEN}`).toString('base64');
+      const result = await getJson(
+        `https://api.twilio.com/2010-04-01/Accounts/${accountSid}/Messages/${sid}.json`,
+        {
+          headers: { Authorization: `Basic ${auth}` },
+          timeoutMs: 10000
+        }
+      );
+      return result.status || null;
+    } catch (error) {
+      logDetails('Could not read Twilio message status:', error.message);
+      return null;
     }
   }
 

--- a/src/utils/http-client.js
+++ b/src/utils/http-client.js
@@ -52,6 +52,26 @@ async function getBuffer(url, { headers = {}, timeoutMs = 15000 } = {}) {
 }
 
 /**
+ * GET a URL and parse the JSON response. Used for lightweight Twilio
+ * resource reads (e.g. polling a message's delivery status).
+ */
+async function getJson(url, { headers = {}, timeoutMs = 15000 } = {}) {
+  let response;
+  try {
+    response = await fetch(url, {
+      headers,
+      signal: AbortSignal.timeout(timeoutMs)
+    });
+  } catch (error) {
+    throw normalizeError(error, url);
+  }
+  if (!response.ok) {
+    throw await toHttpError(response);
+  }
+  return response.json();
+}
+
+/**
  * POST a body (JSON object, FormData, or URLSearchParams) and parse the
  * JSON response. Content-Type is set automatically: explicitly for JSON,
  * by fetch itself for FormData (multipart boundary) and URLSearchParams.
@@ -77,5 +97,6 @@ async function postJson(url, body, { headers = {}, timeoutMs = 30000 } = {}) {
 
 module.exports = {
   getBuffer,
+  getJson,
   postJson
 };

--- a/test/messaging-service.test.js
+++ b/test/messaging-service.test.js
@@ -1,0 +1,113 @@
+// test/messaging-service.test.js
+const { test } = require('node:test');
+const assert = require('node:assert');
+const {
+  splitLongMessage,
+  sendMessages,
+  waitUntilDispatched
+} = require('../src/services/messaging-service');
+
+// A fake TwilioClientWrapper that records the order parts are submitted in
+// and simulates Twilio's status lifecycle: a message starts 'queued' and
+// only advances to 'sent' after `dispatchAfter` status polls. This lets us
+// prove sendMessages waits for part N to leave the queue before part N+1.
+function makeFakeWrapper({ testMode = false, dispatchAfter = 1, statusOverride } = {}) {
+  const sent = [];       // bodies in submission order
+  const statusPolls = []; // sids polled, in order
+  const pollCounts = new Map();
+  let seq = 0;
+
+  return {
+    testMode,
+    hasCredentials: !testMode,
+    sent,
+    statusPolls,
+    async sendMessage(options) {
+      sent.push(options.body);
+      const sid = `SM-${seq++}`;
+      pollCounts.set(sid, 0);
+      return { sid, status: 'queued' };
+    },
+    async getMessageStatus(sid) {
+      statusPolls.push(sid);
+      if (statusOverride !== undefined) return statusOverride;
+      const n = (pollCounts.get(sid) || 0) + 1;
+      pollCounts.set(sid, n);
+      return n >= dispatchAfter ? 'sent' : 'queued';
+    }
+  };
+}
+
+test('splitLongMessage keeps short messages as a single part', () => {
+  assert.deepStrictEqual(splitLongMessage('hello'), ['hello']);
+  assert.deepStrictEqual(splitLongMessage(''), ['']);
+});
+
+test('splitLongMessage splits long messages into ordered contiguous parts', () => {
+  const msg = 'abcdefghij'.repeat(400); // 4000 chars
+  const parts = splitLongMessage(msg, 1500);
+  assert.strictEqual(parts.length, 3);
+  // Parts must reconstruct the original in order (no reordering/loss).
+  assert.strictEqual(parts.join(''), msg);
+  assert.ok(parts[0].length === 1500 && parts[1].length === 1500);
+});
+
+test('waitUntilDispatched returns once status leaves the queue', async () => {
+  const wrapper = makeFakeWrapper({ dispatchAfter: 3 });
+  const status = await waitUntilDispatched(wrapper, 'SM-x', { attempts: 8, intervalMs: 0 });
+  assert.strictEqual(status, 'sent');
+  // Polled exactly until it flipped to 'sent' (queued, queued, sent).
+  assert.strictEqual(wrapper.statusPolls.length, 3);
+});
+
+test('waitUntilDispatched fails open when status never advances', async () => {
+  const wrapper = makeFakeWrapper({ statusOverride: 'queued' });
+  const status = await waitUntilDispatched(wrapper, 'SM-x', { attempts: 4, intervalMs: 0 });
+  assert.strictEqual(status, null);       // gave up rather than blocking forever
+  assert.strictEqual(wrapper.statusPolls.length, 4);
+});
+
+test('waitUntilDispatched fails open when status is unreadable', async () => {
+  const wrapper = makeFakeWrapper({ statusOverride: null });
+  const status = await waitUntilDispatched(wrapper, 'SM-x', { attempts: 4, intervalMs: 0 });
+  assert.strictEqual(status, null);
+  assert.strictEqual(wrapper.statusPolls.length, 1); // null short-circuits immediately
+});
+
+test('sendMessages submits parts in order', async () => {
+  const wrapper = makeFakeWrapper();
+  await sendMessages(wrapper, ['part-1', 'part-2', 'part-3'], '+to', '+from');
+  assert.deepStrictEqual(wrapper.sent, ['part-1', 'part-2', 'part-3']);
+});
+
+test('sendMessages waits for each part to be dispatched before sending the next', async () => {
+  const wrapper = makeFakeWrapper({ dispatchAfter: 1 });
+  await sendMessages(wrapper, ['a', 'b', 'c'], '+to', '+from');
+  // Two boundaries (after a, after b) => at least one poll each; last part
+  // is never polled (nothing follows it).
+  assert.ok(wrapper.statusPolls.length >= 2);
+  // Every poll targets the part that was just sent, before the next goes out.
+  assert.deepStrictEqual(wrapper.statusPolls, ['SM-0', 'SM-1']);
+});
+
+test('sendMessages never polls status in test mode', async () => {
+  const wrapper = makeFakeWrapper({ testMode: true });
+  await sendMessages(wrapper, ['a', 'b'], '+to', '+from');
+  assert.deepStrictEqual(wrapper.sent, ['a', 'b']);
+  assert.strictEqual(wrapper.statusPolls.length, 0);
+});
+
+test('sendMessages does not poll for a single-part message', async () => {
+  const wrapper = makeFakeWrapper();
+  await sendMessages(wrapper, ['only'], '+to', '+from');
+  assert.strictEqual(wrapper.statusPolls.length, 0);
+});
+
+test('sendMessages propagates send failures', async () => {
+  const wrapper = makeFakeWrapper();
+  wrapper.sendMessage = async () => { throw new Error('twilio down'); };
+  await assert.rejects(
+    () => sendMessages(wrapper, ['a', 'b'], '+to', '+from'),
+    /twilio down/
+  );
+});


### PR DESCRIPTION
## Problem
A long transcription is correctly split into parts and sent sequentially, but the **second half sometimes arrives before the first**.

The reorder isn't in our code — parts are submitted in order. Awaiting Twilio's REST POST only confirms a message was **`queued`**, not dispatched to Meta. Two parts queued back-to-back can be picked up by Twilio's queue workers and reach Meta out of order, and WhatsApp orders the chat by Meta's receipt timestamp. The old fixed 500ms delay only spaced out the queuing — purely probabilistic.

## Fix
`sendMessages` now polls each part to a **dispatched** status (past `queued`/`accepted` → `sent`/`delivered`/…) before submitting the next part — the only thing that actually orders them at Meta.

- `src/utils/http-client.js` — native `getJson` helper (no deps added).
- `src/services/twilio-service.js` — `getMessageStatus(sid)`, fail-open, no-op in test mode.
- `src/services/messaging-service.js` — `waitUntilDispatched()` between parts (8 polls × 500ms budget).

**Fail-open** per the repo's Blobs philosophy: if status can't be read or never advances within budget, it proceeds rather than blocking a send. Worst case reverts to the old rare-reorder behaviour; a part is never dropped or blocked forever.

## Tests
New `test/messaging-service.test.js` (registered in `package.json`): ordering, dispatch-wait sequencing, fail-open on stuck/unreadable status, test-mode skip, single-part skip, error propagation. Full suite: **46 pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)