### PR TITLE
Fall back to whisper-1 when gpt-4o-mini-transcribe rejects audio (400); surface OpenAI error text in alerts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,7 +81,7 @@ npx @netlify/zip-it-and-ship-it netlify/functions <outdir> --config '{"*":{"node
 
 ## OpenAI models in use
 
-- Transcription: `gpt-4o-mini-transcribe` (default param in `prepareFormData`)
+- Transcription: `gpt-4o-mini-transcribe` (default param in `prepareFormData`), with a one-shot fallback to `whisper-1` on HTTP 400 — the 4o-transcribe models reject audio longer than 1500 s (25 min), whisper-1 has no duration cap (a >25-min voice note caused a production `processing_error` on 2026-08-18). Upload filename extension is derived from `MediaContentType0` (OpenAI sniffs format from the extension; forwarded mp3/m4a files used to be sent as `.ogg`).
 - Summaries (>150 words): `gpt-4o-mini`
 - Translation fallback: `gpt-4o-mini`
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "start": "node index.js",
     "dev": "nodemon index.js",
-    "test": "node --test test/localization.test.js test/express-flows.test.js test/netlify-functions.test.js test/cost-estimate.test.js test/messaging-service.test.js"
+    "test": "node --test test/localization.test.js test/express-flows.test.js test/netlify-functions.test.js test/cost-estimate.test.js test/messaging-service.test.js test/transcription-service.test.js"
   },
   "engines": {
     "node": ">=18"

--- a/src/services/audio-service.js
+++ b/src/services/audio-service.js
@@ -39,11 +39,43 @@ async function downloadAudio(mediaUrl, headers = {}, req = null) {
   }
 }
 
+// OpenAI sniffs the container format from the upload's file *extension*,
+// so it must match what Twilio actually delivered. WhatsApp voice notes are
+// audio/ogg (opus), but users can also forward audio files (mp3, m4a/aac),
+// and those came through mislabelled as .ogg -> HTTP 400 "invalid file".
+const EXTENSION_BY_CONTENT_TYPE = {
+  'audio/ogg': 'ogg',
+  'audio/opus': 'ogg',
+  'audio/oga': 'oga',
+  'audio/mpeg': 'mp3',
+  'audio/mp3': 'mp3',
+  'audio/mpga': 'mpga',
+  'audio/mp4': 'm4a',
+  'audio/x-m4a': 'm4a',
+  'audio/m4a': 'm4a',
+  'audio/aac': 'm4a',
+  'audio/wav': 'wav',
+  'audio/x-wav': 'wav',
+  'audio/wave': 'wav',
+  'audio/webm': 'webm',
+  'audio/flac': 'flac',
+  'audio/x-flac': 'flac',
+  'audio/amr': 'amr',
+  'video/mp4': 'mp4',
+  'video/mpeg': 'mpeg',
+  'video/webm': 'webm'
+};
+
+function audioFilename(contentType) {
+  const base = String(contentType || '').split(';')[0].trim().toLowerCase();
+  return `audio.${EXTENSION_BY_CONTENT_TYPE[base] || 'ogg'}`;
+}
+
 function prepareFormData(audioData, contentType, model = 'gpt-4o-mini-transcribe') {
   // Native FormData/Blob (Node 18+); fetch sets the multipart boundary.
   const formData = new FormData();
 
-  formData.append('file', new Blob([Buffer.from(audioData)], { type: contentType }), 'audio.ogg');
+  formData.append('file', new Blob([Buffer.from(audioData)], { type: contentType }), audioFilename(contentType));
   formData.append('model', model);
   formData.append('response_format', 'json');
 
@@ -52,5 +84,6 @@ function prepareFormData(audioData, contentType, model = 'gpt-4o-mini-transcribe
 
 module.exports = {
   downloadAudio,
-  prepareFormData
+  prepareFormData,
+  audioFilename
 };

--- a/src/services/audio-service.js
+++ b/src/services/audio-service.js
@@ -66,16 +66,23 @@ const EXTENSION_BY_CONTENT_TYPE = {
   'video/webm': 'webm'
 };
 
+// Bare MIME type, parameters stripped: 'audio/ogg; codecs=opus' -> 'audio/ogg'.
+// OpenAI support's own workaround for gpt-4o-transcribe 400s on Opus
+// uploads was "don't pass ;codecs=opus" -- so never put it on the part.
+function baseMimeType(contentType) {
+  return String(contentType || '').split(';')[0].trim().toLowerCase();
+}
+
 function audioFilename(contentType) {
-  const base = String(contentType || '').split(';')[0].trim().toLowerCase();
-  return `audio.${EXTENSION_BY_CONTENT_TYPE[base] || 'ogg'}`;
+  return `audio.${EXTENSION_BY_CONTENT_TYPE[baseMimeType(contentType)] || 'ogg'}`;
 }
 
 function prepareFormData(audioData, contentType, model = 'gpt-4o-mini-transcribe') {
   // Native FormData/Blob (Node 18+); fetch sets the multipart boundary.
   const formData = new FormData();
 
-  formData.append('file', new Blob([Buffer.from(audioData)], { type: contentType }), audioFilename(contentType));
+  const mimeType = baseMimeType(contentType) || 'audio/ogg';
+  formData.append('file', new Blob([Buffer.from(audioData)], { type: mimeType }), audioFilename(contentType));
   formData.append('model', model);
   formData.append('response_format', 'json');
 

--- a/src/services/transcription-service.js
+++ b/src/services/transcription-service.js
@@ -75,28 +75,67 @@ async function transcribeAudio(formData, apiKey, req = null) {
   
   // Normal production code
   try {
-    logDetails('Sending request to OpenAI Whisper API...');
-
-    const data = await postJson(
-      'https://api.openai.com/v1/audio/transcriptions',
-      formData,
-      {
-        headers: { Authorization: `Bearer ${apiKey}` },
-        timeoutMs: 30000
-      }
-    );
-
-    logDetails('Received response from Whisper API', {
-      hasText: !!data.text
-    });
-
-    return data.text.trim();
+    return await requestTranscription(formData, apiKey);
   } catch (error) {
+    const status = error.response && error.response.status;
+    const model = formData.get('model');
+    // gpt-4o(-mini)-transcribe rejects input longer than 1500s (25 min)
+    // with HTTP 400; whisper-1 has no duration cap (only the 25MB upload
+    // limit, which our size guard already enforces). A 400 is also what
+    // an unsupported container yields, so one fallback attempt covers
+    // both without costing anything on the failure path (4xx are unbilled).
+    if (status === 400 && model && model !== FALLBACK_MODEL) {
+      logDetails(`Transcription rejected by ${model} (${error.message}) - retrying with ${FALLBACK_MODEL}`);
+      try {
+        return await requestTranscription(withModel(formData, FALLBACK_MODEL), apiKey);
+      } catch (fallbackError) {
+        logDetails('Error transcribing audio (fallback):', fallbackError);
+        throw fallbackError;
+      }
+    }
     logDetails('Error transcribing audio:', error);
     throw error;
   }
 }
 
+const FALLBACK_MODEL = 'whisper-1';
+
+async function requestTranscription(formData, apiKey) {
+  logDetails(`Sending request to OpenAI transcription API (${formData.get('model')})...`);
+
+  const data = await postJson(
+    'https://api.openai.com/v1/audio/transcriptions',
+    formData,
+    {
+      headers: { Authorization: `Bearer ${apiKey}` },
+      timeoutMs: 30000
+    }
+  );
+
+  logDetails('Received response from transcription API', {
+    hasText: !!data.text
+  });
+
+  return data.text.trim();
+}
+
+// Copy a transcription FormData with a different model (FormData has no
+// clone; the File entry is shared by reference, not re-buffered).
+function withModel(formData, model) {
+  const copy = new FormData();
+  for (const [key, value] of formData.entries()) {
+    if (key === 'model') continue;
+    if (value instanceof Blob) {
+      copy.append(key, value, value.name || 'audio.ogg');
+    } else {
+      copy.append(key, value);
+    }
+  }
+  copy.append('model', model);
+  return copy;
+}
+
 module.exports = {
-  transcribeAudio
+  transcribeAudio,
+  FALLBACK_MODEL
 };

--- a/src/utils/http-client.js
+++ b/src/utils/http-client.js
@@ -25,7 +25,22 @@ async function toHttpError(response) {
   try {
     error.response.data = await response.json();
   } catch (e) { /* non-JSON error body */ }
+  // Surface the provider's own explanation (OpenAI: {error:{message}},
+  // Twilio: {message}) in error.message so logs and the operator alert say
+  // *why* -- "HTTP 400" alone is undiagnosable once logs have rotated.
+  const detail = extractErrorDetail(error.response.data);
+  if (detail) {
+    error.message += `: ${detail}`;
+  }
   return error;
+}
+
+function extractErrorDetail(data) {
+  if (!data || typeof data !== 'object') return null;
+  const candidate = (data.error && typeof data.error === 'object' && data.error.message)
+    || (typeof data.error === 'string' && data.error)
+    || data.message;
+  return typeof candidate === 'string' && candidate.trim() ? candidate.trim().slice(0, 300) : null;
 }
 
 /**
@@ -98,5 +113,6 @@ async function postJson(url, body, { headers = {}, timeoutMs = 30000 } = {}) {
 module.exports = {
   getBuffer,
   getJson,
-  postJson
+  postJson,
+  extractErrorDetail
 };

--- a/test/transcription-service.test.js
+++ b/test/transcription-service.test.js
@@ -1,0 +1,129 @@
+// test/transcription-service.test.js
+// Offline tests for the OpenAI transcription request path: content-type
+// aware upload filenames, the whisper-1 fallback on HTTP 400 (25-minute
+// cap on gpt-4o-mini-transcribe / unsupported containers), and provider
+// error messages being surfaced on error.message for logs and alerts.
+// fetch is stubbed; nothing leaves the process.
+const { test, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert');
+
+const { prepareFormData, audioFilename } = require('../src/services/audio-service');
+const { transcribeAudio, FALLBACK_MODEL } = require('../src/services/transcription-service');
+const { postJson, extractErrorDetail } = require('../src/utils/http-client');
+
+const realFetch = globalThis.fetch;
+let calls;
+
+function jsonResponse(status, body) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' }
+  });
+}
+
+// Queue of responses; each fetch call records its parsed FormData.
+function stubFetch(responses) {
+  calls = [];
+  globalThis.fetch = async (url, init) => {
+    const form = init && init.body instanceof FormData ? init.body : null;
+    calls.push({
+      url,
+      model: form ? form.get('model') : null,
+      fileName: form && form.get('file') ? form.get('file').name : null,
+      fileSize: form && form.get('file') ? form.get('file').size : null
+    });
+    const next = responses.shift();
+    if (!next) throw new Error('unexpected extra fetch call');
+    return next;
+  };
+}
+
+beforeEach(() => { calls = []; });
+afterEach(() => { globalThis.fetch = realFetch; });
+
+test('audioFilename maps Twilio media content types to the extension OpenAI expects', () => {
+  assert.strictEqual(audioFilename('audio/ogg'), 'audio.ogg');
+  assert.strictEqual(audioFilename('audio/ogg; codecs=opus'), 'audio.ogg');
+  assert.strictEqual(audioFilename('audio/mpeg'), 'audio.mp3');
+  assert.strictEqual(audioFilename('audio/mp4'), 'audio.m4a');
+  assert.strictEqual(audioFilename('audio/aac'), 'audio.m4a');
+  assert.strictEqual(audioFilename('AUDIO/WAV'), 'audio.wav');
+  assert.strictEqual(audioFilename('video/mp4'), 'audio.mp4');
+  // Unknown / missing -> ogg (the WhatsApp voice-note default)
+  assert.strictEqual(audioFilename(undefined), 'audio.ogg');
+  assert.strictEqual(audioFilename('application/octet-stream'), 'audio.ogg');
+});
+
+test('prepareFormData names the upload from the content type and sets the default model', () => {
+  const form = prepareFormData(Buffer.from('abc'), 'audio/mpeg');
+  assert.strictEqual(form.get('file').name, 'audio.mp3');
+  assert.strictEqual(form.get('model'), 'gpt-4o-mini-transcribe');
+  assert.strictEqual(form.get('response_format'), 'json');
+});
+
+test('HTTP errors carry the provider error message (OpenAI and Twilio shapes)', async () => {
+  stubFetch([
+    jsonResponse(400, { error: { message: 'audio duration 1712 seconds is longer than 1500 seconds', type: 'invalid_request_error' } })
+  ]);
+  await assert.rejects(
+    () => postJson('https://api.openai.com/v1/audio/transcriptions', new FormData(), {}),
+    (err) => {
+      assert.strictEqual(err.response.status, 400);
+      assert.match(err.message, /^HTTP 400 from .*: audio duration 1712 seconds is longer than 1500 seconds$/);
+      return true;
+    }
+  );
+
+  assert.strictEqual(extractErrorDetail({ message: 'Unable to create record', code: 21211 }), 'Unable to create record');
+  assert.strictEqual(extractErrorDetail({ error: 'plain string' }), 'plain string');
+  assert.strictEqual(extractErrorDetail(null), null);
+  assert.strictEqual(extractErrorDetail({ error: {} }), null);
+  assert.strictEqual(extractErrorDetail('x'.repeat(5)), null);
+});
+
+test('a 400 from gpt-4o-mini-transcribe falls back to whisper-1 with the same file', async () => {
+  stubFetch([
+    jsonResponse(400, { error: { message: 'audio duration 1712 seconds is longer than 1500 seconds' } }),
+    jsonResponse(200, { text: '  long note transcribed  ' })
+  ]);
+  const form = prepareFormData(Buffer.from('fake-ogg-bytes'), 'audio/ogg');
+  const text = await transcribeAudio(form, 'sk-test');
+
+  assert.strictEqual(text, 'long note transcribed');
+  assert.strictEqual(calls.length, 2);
+  assert.strictEqual(calls[0].model, 'gpt-4o-mini-transcribe');
+  assert.strictEqual(calls[1].model, FALLBACK_MODEL);
+  assert.strictEqual(calls[1].fileName, 'audio.ogg');
+  assert.strictEqual(calls[1].fileSize, calls[0].fileSize);
+  // The caller's FormData is not mutated.
+  assert.strictEqual(form.get('model'), 'gpt-4o-mini-transcribe');
+});
+
+test('a 400 from whisper-1 itself is not retried (no loop)', async () => {
+  stubFetch([
+    jsonResponse(400, { error: { message: 'Invalid file format.' } }),
+    jsonResponse(400, { error: { message: 'Invalid file format.' } })
+  ]);
+  const form = prepareFormData(Buffer.from('not-audio'), 'audio/amr');
+  await assert.rejects(() => transcribeAudio(form, 'sk-test'), /HTTP 400 from .*: Invalid file format\./);
+  assert.strictEqual(calls.length, 2);
+  assert.strictEqual(calls[1].model, FALLBACK_MODEL);
+});
+
+test('non-400 errors are not retried with the fallback model', async () => {
+  stubFetch([jsonResponse(429, { error: { message: 'Rate limit reached' } })]);
+  const form = prepareFormData(Buffer.from('x'), 'audio/ogg');
+  await assert.rejects(() => transcribeAudio(form, 'sk-test'), (err) => {
+    assert.strictEqual(err.response.status, 429); // pipeline classifies on this
+    assert.match(err.message, /Rate limit reached/);
+    return true;
+  });
+  assert.strictEqual(calls.length, 1);
+});
+
+test('success on the first attempt makes exactly one request', async () => {
+  stubFetch([jsonResponse(200, { text: 'hello' })]);
+  const form = prepareFormData(Buffer.from('x'), 'audio/ogg');
+  assert.strictEqual(await transcribeAudio(form, 'sk-test'), 'hello');
+  assert.strictEqual(calls.length, 1);
+});

--- a/test/transcription-service.test.js
+++ b/test/transcription-service.test.js
@@ -57,8 +57,19 @@ test('audioFilename maps Twilio media content types to the extension OpenAI expe
 test('prepareFormData names the upload from the content type and sets the default model', () => {
   const form = prepareFormData(Buffer.from('abc'), 'audio/mpeg');
   assert.strictEqual(form.get('file').name, 'audio.mp3');
+  assert.strictEqual(form.get('file').type, 'audio/mpeg');
   assert.strictEqual(form.get('model'), 'gpt-4o-mini-transcribe');
   assert.strictEqual(form.get('response_format'), 'json');
+});
+
+test('prepareFormData strips MIME parameters (OpenAI chokes on ";codecs=opus") and defaults to audio/ogg', () => {
+  const opus = prepareFormData(Buffer.from('abc'), 'audio/ogg; codecs=opus');
+  assert.strictEqual(opus.get('file').type, 'audio/ogg');
+  assert.strictEqual(opus.get('file').name, 'audio.ogg');
+
+  const missing = prepareFormData(Buffer.from('abc'), undefined);
+  assert.strictEqual(missing.get('file').type, 'audio/ogg');
+  assert.strictEqual(missing.get('file').name, 'audio.ogg');
 });
 
 test('HTTP errors carry the provider error message (OpenAI and Twilio shapes)', async () => {


### PR DESCRIPTION
## Context
Operator alert on 2026-08-18:

> ⚠️ Josephine: transcription failed for whatsapp:+447504… (MM496c7eb8…): HTTP 400 from https://api.openai.com/v1/audio/transcriptions

Investigation: the note reached Netlify, was dispatched to the background worker, the (authenticated) Twilio download succeeded and passed the size guard, and **OpenAI rejected the audio itself with 400**. The exact OpenAI message had already rotated out of Netlify's 24 h function-log retention, and the alert only carried the status line — so this PR fixes both the likely causes *and* the blind spot.

## Causes addressed
1. **Voice notes longer than 25 minutes.** `gpt-4o-mini-transcribe` (and `gpt-4o-transcribe`) reject input over 1500 s with HTTP 400. `whisper-1` has no duration cap — only the 25 MB upload limit, which our size guard already enforces. On a 400 from the primary model we now retry **once** with `whisper-1`. 4xx responses are unbilled so the failure path costs nothing extra; `whisper-1` itself is never retried (no loop), and non-400 errors (429, 5xx, timeouts) keep their existing classification.
2. **Non-OGG media.** `prepareFormData` named every upload `audio.ogg` regardless of `MediaContentType0`, and OpenAI sniffs the container from the extension — a forwarded mp3/m4a/aac file or a video note therefore read as a corrupt ogg. The extension is now derived from the Twilio content type (ogg stays the default for WhatsApp voice notes).

## Diagnostics
`toHttpError` now appends the provider's own explanation (OpenAI `{error:{message}}`, Twilio `{message}`) to `error.message`. Since the pipeline puts `error.message` into `result.error` and the background worker puts that into the operator alert, the next alert will read e.g. `HTTP 400 from …/audio/transcriptions: audio duration 1712 seconds is longer than 1500 seconds` — diagnosable from the phone, no log archaeology. The error shape the pipeline classifies on (`error.response.status`, `code === 'ECONNABORTED'`) is unchanged.

## Verification
- New `test/transcription-service.test.js` (offline, `fetch` stubbed): filename mapping, fallback sends the *same* file with `model=whisper-1` and doesn't mutate the caller's FormData, whisper-1 400 isn't retried, 429 isn't retried, success = one request, provider-message surfacing for both shapes. Registered in `npm test`.
- `npm test` — 53/53 pass.
- `zip-it-and-ship-it` bundle of the background function: no externalized `__require(...)`, the change is in the bundle.
- CLAUDE.md "OpenAI models in use" updated.

## Not done / open
- I couldn't confirm which of the two causes hit on the 18th (logs rotated). If Franc remembers the note's length (>25 min?) or whether it was a forwarded audio file, that settles it — but both are covered either way.
- Netlify's 24 h log retention is what made this hard; a Log Drain (or just a longer-lived marker payload in Blobs) would help next time. Separate decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
