### PR TITLE
Send operator alerts over WhatsApp from the live sender (fixes silent 21660 alert failures)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,7 +88,7 @@ npx @netlify/zip-it-and-ship-it netlify/functions <outdir> --config '{"*":{"node
 ## Environment variables
 
 Core: `OPENAI_API_KEY`, `ACCOUNT_SID`, `AUTH_TOKEN`, `TWILIO_PHONE_NUMBER`, `PORT` (Express only).
-Netlify-only: `INTERNAL_API_SECRET` (webhook→background auth, required), `TWILIO_WEBHOOK_URL` (signature validation), `ADMIN_PHONE` (optional — WhatsApp alert to the operator on `processing_error`, debounced 1/hour via Blobs), `TWILIO_SIGNATURE_VALIDATION=off` (dev only). `URL` is auto-provided by Netlify.
+Netlify-only: `INTERNAL_API_SECRET` (webhook→background auth, required), `TWILIO_WEBHOOK_URL` (signature validation), `ADMIN_PHONE` (optional — WhatsApp alert to the operator on `processing_error`, debounced 1/hour via Blobs; `whatsapp:` prefix is added automatically, and the alert is sent from the sender the user messaged, not `TWILIO_PHONE_NUMBER`), `TWILIO_SIGNATURE_VALIDATION=off` (dev only). `URL` is auto-provided by Netlify.
 Changing an env var in Netlify requires a **redeploy** to take effect.
 
 ## Deployment & rollback

--- a/netlify/functions/transcribe-background.mjs
+++ b/netlify/functions/transcribe-background.mjs
@@ -27,6 +27,25 @@ import { logDetails } from '../../src/utils/logging-utils.js';
 const ALERT_MARKER_KEY = '_admin-alert-last';
 const ALERT_MUTE_MS = 60 * 60 * 1000; // one alert per hour
 
+// Twilio treats a bare E.164 number as SMS. The alert must be a WhatsApp
+// message on both ends, or it fails with 21660 ("From number not owned by
+// account") -- which is exactly what silently ate every alert from
+// 2026-08-15 to 08-17 (env held the old sandbox number, un-prefixed).
+function asWhatsApp(phone) {
+  const p = String(phone || '').trim();
+  if (!p) return p;
+  return p.startsWith('whatsapp:') ? p : `whatsapp:${p}`;
+}
+
+// Send the alert from the sender the user just messaged (params.To): that
+// sender is provably live on this account, unlike TWILIO_PHONE_NUMBER,
+// which can go stale after a sender migration. Env is only a fallback.
+function alertSender(params) {
+  return asWhatsApp(params.To || process.env.TWILIO_PHONE_NUMBER);
+}
+
+export { asWhatsApp, alertSender };
+
 /**
  * Send a WhatsApp alert to the operator (ADMIN_PHONE), debounced via the
  * Blobs store. Best-effort on every level: if Blobs is down we alert
@@ -44,8 +63,8 @@ async function sendAdminAlert(store, twilioClient, result, params) {
     }
     await twilioClient.sendMessage({
       body: `⚠️ Josephine: transcription failed for ${params.From || 'unknown'} (${params.MessageSid}): ${result.error || 'unknown error'}. Alerts muted for 1h.`,
-      from: process.env.TWILIO_PHONE_NUMBER,
-      to: process.env.ADMIN_PHONE
+      from: alertSender(params),
+      to: asWhatsApp(process.env.ADMIN_PHONE)
     });
     logDetails('Admin alert sent');
   } catch (alertError) {

--- a/test/netlify-functions.test.js
+++ b/test/netlify-functions.test.js
@@ -158,3 +158,25 @@ test('background runs the pipeline and classifies download failure', async () =>
   assert.strictEqual(r.status, 200);
   assert.strictEqual(r.body, 'processing_error');
 });
+
+test('admin alert is always a WhatsApp message, sent from the sender the user messaged', async () => {
+  // Regression: from 2026-08-15 to 08-17 every operator alert failed with
+  // Twilio 21660 because env held a bare (SMS) number for a stale sandbox
+  // sender. The alert must use whatsapp: on both ends and prefer the live
+  // sender from the webhook over TWILIO_PHONE_NUMBER.
+  const { asWhatsApp, alertSender } = await import('../netlify/functions/transcribe-background.mjs');
+
+  assert.strictEqual(asWhatsApp('+447753980466'), 'whatsapp:+447753980466');
+  assert.strictEqual(asWhatsApp('whatsapp:+447753980466'), 'whatsapp:+447753980466');
+  assert.strictEqual(asWhatsApp(' +44 7753 980466 '), 'whatsapp:+44 7753 980466');
+  assert.strictEqual(asWhatsApp(undefined), '');
+
+  const prevEnv = process.env.TWILIO_PHONE_NUMBER;
+  process.env.TWILIO_PHONE_NUMBER = '+14155238886'; // stale sandbox number
+  try {
+    assert.strictEqual(alertSender({ To: 'whatsapp:+447450325919' }), 'whatsapp:+447450325919');
+    assert.strictEqual(alertSender({}), 'whatsapp:+14155238886');
+  } finally {
+    if (prevEnv === undefined) delete process.env.TWILIO_PHONE_NUMBER; else process.env.TWILIO_PHONE_NUMBER = prevEnv;
+  }
+});


### PR DESCRIPTION
## What the Twilio log showed
Every operator alert from **2026-08-15 → 08-17** failed with **Error 21660** ("Mismatch between the 'From' number and the account"):

| When | From | To | Status |
|---|---|---|---|
| Aug 15 12:26:54 | `+14155238886` | `+447753980466` | Failed 21660 |
| Aug 15 17:37:00 | `+14155238886` | `+447753980466` | Failed 21660 |
| Aug 16 09:15:24 | `+14155238886` | `+447753980466` | Failed 21660 |
| Aug 17 08:43:08 | `+14155238886` | `+447753980466` | Failed 21660 |

Both numbers bare E.164 → Twilio treated it as **SMS** from the old **sandbox** number (still in `TWILIO_PHONE_NUMBER`), which this account doesn't own as an SMS sender. Each of those is a `processing_error` incident (OpenAI 400, see #37) that the operator never heard about, while users were receiving the error reply.

## Fix
- Alert `From` = `params.To` — the WhatsApp sender the user actually messaged (`whatsapp:+447450325919`), which is provably live on this account. `TWILIO_PHONE_NUMBER` is only a fallback.
- `whatsapp:` prefix added automatically to both `From` and `To` if missing.

No dependence on fixing env vars, though updating `TWILIO_PHONE_NUMBER` to `whatsapp:+447450325919` in Netlify is still recommended for hygiene.

## Verification
- Regression test in `test/netlify-functions.test.js` (helpers exported from the background function). `npm test` → 55/55.
- CLAUDE.md env-var note updated.

## Note on the bigger picture (not addressed here)
The Twilio log also shows **no inbound messages at all since Aug 17 08:43**, and the WhatsApp sender `+447450325919` is **Offline** in Senders Hub — that's a Meta/Twilio-side sender problem, separate from code. Details in the session notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
